### PR TITLE
feat: add Snowflake Horizon Catalog as a named catalog option

### DIFF
--- a/src/data/compatibility-data.json
+++ b/src/data/compatibility-data.json
@@ -316,6 +316,13 @@
       "description": "Databricks Unity Catalog providing unified governance for data and AI assets, with Iceberg REST Catalog API support"
     },
     {
+      "id": "snowflake-open-catalog",
+      "name": "Snowflake Open Catalog",
+      "category": "catalog-support",
+      "introducedIn": "v2",
+      "description": "Snowflake Open Catalog \u2014 Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
+    },
+    {
       "id": "hadoop-catalog",
       "name": "Hadoop Catalog",
       "category": "catalog-support",
@@ -7144,6 +7151,380 @@
       "level": "unknown",
       "notes": "Kafka Connect V3 lineage support is not yet documented",
       "caveats": []
+    },
+    "aws-athena:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Athena uses AWS Glue Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-athena:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Athena does not support external REST catalogs.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-glue:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Open Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "caveats": [
+        "Requires bundling Iceberg REST catalog dependency in Glue job",
+        "Not a native Glue catalog integration"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-glue:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "V3 support via Glue Spark depends on Iceberg library version used; REST catalog connectivity pattern unchanged.",
+      "caveats": [
+        "V3 support depends on Iceberg library version bundled in Glue job"
+      ],
+      "links": []
+    },
+    "aws-emr:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-emr:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support via EMR Spark requires iceberg-spark-runtime 1.7.0+.",
+      "caveats": [
+        "Requires iceberg-spark-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-firehose:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Firehose is a write-only delivery service that uses AWS Glue Catalog exclusively and does not support REST catalog connections.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-firehose:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Firehose does not support Iceberg V3.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-managed-flink:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Amazon Managed Flink can connect to Snowflake Open Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
+      "caveats": [
+        "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-managed-flink:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support requires bundling iceberg-flink-runtime 1.7.0+. REST catalog connectivity unchanged.",
+      "caveats": [
+        "Requires iceberg-flink-runtime 1.7.0+ for V3 table support",
+        "Iceberg is not a pre-built connector"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "google-bigquery:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "BigQuery uses its own managed metastore and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "google-bigquery:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "BigQuery does not support external REST catalogs.",
+      "caveats": [],
+      "links": []
+    },
+    "google-dataproc:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Dataproc runs Spark and supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "google-dataproc:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support via Dataproc Spark requires iceberg-spark-runtime 1.7.0+.",
+      "caveats": [
+        "Requires iceberg-spark-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "azure-synapse:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Azure Synapse Analytics uses its own catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "azure-synapse:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Azure Synapse does not support external REST catalogs.",
+      "caveats": [],
+      "links": []
+    },
+    "azure-fabric:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Azure Fabric uses its own OneLake catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "azure-fabric:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Azure Fabric does not support external REST catalogs.",
+      "caveats": [],
+      "links": []
+    },
+    "databricks:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "Databricks can connect to Snowflake Open Catalog via ICEBERG_REST catalog integration. Unity Catalog is the primary catalog; cross-catalog queries have limitations.",
+      "caveats": [
+        "Unity Catalog is the primary catalog; Open Catalog is an external REST catalog",
+        "Cross-catalog write operations may have limitations",
+        "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "databricks:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "V3 support for Databricks connecting to Snowflake Open Catalog not yet documented.",
+      "caveats": [
+        "V3 cross-catalog support not yet documented"
+      ],
+      "links": []
+    },
+    "snowflake:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Native integration \u2014 Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Open Catalog as the REST endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "snowflake:snowflake-open-catalog:v3": {
+      "level": "full",
+      "notes": "Full support for Iceberg V3 tables via Snowflake Open Catalog. Public Preview as of March 2026.",
+      "caveats": [
+        "Public Preview as of March 2026"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "duckdb:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "DuckDB Iceberg extension supports REST catalog for reads and writes. Configure with ATTACH using the Open Catalog REST endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "duckdb:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "DuckDB V3 Iceberg table support is partial; REST catalog connectivity to Open Catalog is not yet explicitly documented for V3.",
+      "caveats": [
+        "V3 catalog support via DuckDB not yet documented"
+      ],
+      "links": []
+    },
+    "clickhouse:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "ClickHouse supports REST catalog via the IcebergCatalog table function. Connection to Snowflake Open Catalog follows the same REST catalog configuration.",
+      "caveats": [
+        "REST catalog support available but with configuration complexity",
+        "Feature set may be limited compared to native catalog integrations"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "clickhouse:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "ClickHouse V3 Iceberg support is not yet documented; REST catalog connectivity pattern unchanged.",
+      "caveats": [
+        "V3 support not yet documented in ClickHouse"
+      ],
+      "links": []
+    },
+    "daft:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Daft supports REST catalog natively via PyIceberg integration. Configure with type=rest and the Open Catalog endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "daft:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "Daft V3 REST catalog support not yet documented.",
+      "caveats": [
+        "V3 support via Daft not yet documented"
+      ],
+      "links": []
+    },
+    "spark:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Spark Iceberg connector supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest and the Open Catalog endpoint URI.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "spark:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support depends on iceberg-spark-runtime version (1.7.0+ recommended). REST catalog connectivity unchanged.",
+      "caveats": [
+        "Requires iceberg-spark-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "flink:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Flink Iceberg connector supports REST catalog. Configure with catalog-type=rest and the Open Catalog endpoint URI.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "flink:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support depends on iceberg-flink-runtime version (1.7.0+ recommended). REST catalog connectivity unchanged.",
+      "caveats": [
+        "Requires iceberg-flink-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "kafka-connect:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "Kafka Connect Iceberg sink supports REST catalog type natively. Snowflake Open Catalog implements the same REST Catalog spec as Apache Polaris.",
+      "caveats": [
+        "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "kafka-connect:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "REST catalog support unchanged for V3. V3 feature support depends on Iceberg library version bundled.",
+      "caveats": [
+        "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "pyiceberg:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "PyIceberg has first-class REST catalog support. Configure with type=rest and the Open Catalog endpoint in pyiceberg config.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "pyiceberg:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "PyIceberg REST catalog support is available; V3 feature support depends on PyIceberg version (0.8.0+ recommended).",
+      "caveats": [
+        "Requires PyIceberg 0.8.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-redshift:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Amazon Redshift uses AWS Glue Data Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-redshift:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Redshift does not support Iceberg V3 or external REST catalogs.",
+      "caveats": [],
+      "links": []
     }
   }
 }

--- a/src/data/compatibility-data.json
+++ b/src/data/compatibility-data.json
@@ -316,11 +316,11 @@
       "description": "Databricks Unity Catalog providing unified governance for data and AI assets, with Iceberg REST Catalog API support"
     },
     {
-      "id": "snowflake-open-catalog",
-      "name": "Snowflake Open Catalog",
+      "id": "snowflake-horizon-catalog",
+      "name": "Snowflake Horizon Catalog",
       "category": "catalog-support",
       "introducedIn": "v2",
-      "description": "Snowflake Open Catalog \u2014 Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
+      "description": "Snowflake Horizon Catalog \u2014 Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
     },
     {
       "id": "hadoop-catalog",
@@ -1924,7 +1924,7 @@
     },
     "snowflake:catalog-integration:v2": {
       "level": "full",
-      "notes": "Snowflake supports its own catalog, Snowflake Open Catalog (Polaris), and external catalogs",
+      "notes": "Snowflake supports its own catalog, Snowflake Horizon Catalog (Polaris), and external catalogs",
       "caveats": []
     },
     "snowflake:catalog-integration:v3": {
@@ -1980,7 +1980,7 @@
     },
     "snowflake:polaris:v2": {
       "level": "full",
-      "notes": "Snowflake Open Catalog is built on Polaris; native integration",
+      "notes": "Snowflake Horizon Catalog is built on Polaris; native integration",
       "caveats": []
     },
     "snowflake:polaris:v3": {
@@ -7152,33 +7152,42 @@
       "notes": "Kafka Connect V3 lineage support is not yet documented",
       "caveats": []
     },
-    "aws-athena:snowflake-open-catalog:v2": {
-      "level": "none",
-      "notes": "Athena uses AWS Glue Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
-      "caveats": [],
-      "links": []
+    "aws-athena:snowflake-horizon-catalog:v2": {
+      "level": "partial",
+      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
+      "caveats": [
+        "Read-only \u2014 write operations not supported via Athena",
+        "Requires AWS Glue Catalog Federation configuration",
+        "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
+        }
+      ]
     },
-    "aws-athena:snowflake-open-catalog:v3": {
+    "aws-athena:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Athena does not support external REST catalogs.",
       "caveats": [],
       "links": []
     },
-    "aws-glue:snowflake-open-catalog:v2": {
+    "aws-glue:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "AWS Glue Spark jobs can connect to Snowflake Open Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
       "caveats": [
         "Requires bundling Iceberg REST catalog dependency in Glue job",
         "Not a native Glue catalog integration"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-glue:snowflake-open-catalog:v3": {
+    "aws-glue:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "V3 support via Glue Spark depends on Iceberg library version used; REST catalog connectivity pattern unchanged.",
       "caveats": [
@@ -7186,18 +7195,18 @@
       ],
       "links": []
     },
-    "aws-emr:snowflake-open-catalog:v2": {
+    "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-emr:snowflake-open-catalog:v3": {
+    "aws-emr:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support via EMR Spark requires iceberg-spark-runtime 1.7.0+.",
       "caveats": [
@@ -7205,37 +7214,37 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-firehose:snowflake-open-catalog:v2": {
+    "aws-firehose:snowflake-horizon-catalog:v2": {
       "level": "none",
       "notes": "Firehose is a write-only delivery service that uses AWS Glue Catalog exclusively and does not support REST catalog connections.",
       "caveats": [],
       "links": []
     },
-    "aws-firehose:snowflake-open-catalog:v3": {
+    "aws-firehose:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Firehose does not support Iceberg V3.",
       "caveats": [],
       "links": []
     },
-    "aws-managed-flink:snowflake-open-catalog:v2": {
+    "aws-managed-flink:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Amazon Managed Flink can connect to Snowflake Open Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
+      "notes": "Amazon Managed Flink can connect to Snowflake Horizon Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
       "caveats": [
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-managed-flink:snowflake-open-catalog:v3": {
+    "aws-managed-flink:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support requires bundling iceberg-flink-runtime 1.7.0+. REST catalog connectivity unchanged.",
       "caveats": [
@@ -7244,35 +7253,35 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "google-bigquery:snowflake-open-catalog:v2": {
+    "google-bigquery:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "BigQuery uses its own managed metastore and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "BigQuery uses its own managed metastore and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "google-bigquery:snowflake-open-catalog:v3": {
+    "google-bigquery:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "BigQuery does not support external REST catalogs.",
       "caveats": [],
       "links": []
     },
-    "google-dataproc:snowflake-open-catalog:v2": {
+    "google-dataproc:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "Dataproc runs Spark and supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "google-dataproc:snowflake-open-catalog:v3": {
+    "google-dataproc:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support via Dataproc Spark requires iceberg-spark-runtime 1.7.0+.",
       "caveats": [
@@ -7280,94 +7289,94 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "azure-synapse:snowflake-open-catalog:v2": {
+    "azure-synapse:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "Azure Synapse Analytics uses its own catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "Azure Synapse Analytics uses its own catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "azure-synapse:snowflake-open-catalog:v3": {
+    "azure-synapse:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Azure Synapse does not support external REST catalogs.",
       "caveats": [],
       "links": []
     },
-    "azure-fabric:snowflake-open-catalog:v2": {
+    "azure-fabric:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "Azure Fabric uses its own OneLake catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "Azure Fabric uses its own OneLake catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "azure-fabric:snowflake-open-catalog:v3": {
+    "azure-fabric:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Azure Fabric does not support external REST catalogs.",
       "caveats": [],
       "links": []
     },
-    "databricks:snowflake-open-catalog:v2": {
+    "databricks:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Databricks can connect to Snowflake Open Catalog via ICEBERG_REST catalog integration. Unity Catalog is the primary catalog; cross-catalog queries have limitations.",
+      "notes": "Databricks can connect to Snowflake Horizon Catalog via ICEBERG_REST catalog integration for read access. Databricks does not support writes to externally managed Iceberg tables \u2014 this is a Databricks engine limitation, not a Horizon Catalog limitation. Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog.",
       "caveats": [
-        "Unity Catalog is the primary catalog; Open Catalog is an external REST catalog",
-        "Cross-catalog write operations may have limitations",
-        "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)"
+        "Read-only \u2014 Databricks does not support writes to externally managed Iceberg tables (Databricks engine limitation)",
+        "Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog",
+        "Managed Iceberg tables in Databricks are in Public Preview (requires DBR 16.4 LTS+)"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "databricks:snowflake-open-catalog:v3": {
+    "databricks:snowflake-horizon-catalog:v3": {
       "level": "unknown",
-      "notes": "V3 support for Databricks connecting to Snowflake Open Catalog not yet documented.",
+      "notes": "V3 support for Databricks connecting to Snowflake Horizon Catalog not yet documented.",
       "caveats": [
         "V3 cross-catalog support not yet documented"
       ],
       "links": []
     },
-    "snowflake:snowflake-open-catalog:v2": {
+    "snowflake:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Native integration \u2014 Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Open Catalog as the REST endpoint.",
+      "notes": "Native integration \u2014 Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Horizon Catalog as the REST endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "snowflake:snowflake-open-catalog:v3": {
+    "snowflake:snowflake-horizon-catalog:v3": {
       "level": "full",
-      "notes": "Full support for Iceberg V3 tables via Snowflake Open Catalog. Public Preview as of March 2026.",
+      "notes": "Full support for Iceberg V3 tables via Snowflake Horizon Catalog. Public Preview as of March 2026.",
       "caveats": [
         "Public Preview as of March 2026"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "duckdb:snowflake-open-catalog:v2": {
+    "duckdb:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "DuckDB Iceberg extension supports REST catalog for reads and writes. Configure with ATTACH using the Open Catalog REST endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "duckdb:snowflake-open-catalog:v3": {
+    "duckdb:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "DuckDB V3 Iceberg table support is partial; REST catalog connectivity to Open Catalog is not yet explicitly documented for V3.",
       "caveats": [
@@ -7375,21 +7384,21 @@
       ],
       "links": []
     },
-    "clickhouse:snowflake-open-catalog:v2": {
+    "clickhouse:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "ClickHouse supports REST catalog via the IcebergCatalog table function. Connection to Snowflake Open Catalog follows the same REST catalog configuration.",
+      "notes": "ClickHouse supports REST catalog via the IcebergCatalog table function. Connection to Snowflake Horizon Catalog follows the same REST catalog configuration.",
       "caveats": [
         "REST catalog support available but with configuration complexity",
         "Feature set may be limited compared to native catalog integrations"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "clickhouse:snowflake-open-catalog:v3": {
+    "clickhouse:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "ClickHouse V3 Iceberg support is not yet documented; REST catalog connectivity pattern unchanged.",
       "caveats": [
@@ -7397,18 +7406,18 @@
       ],
       "links": []
     },
-    "daft:snowflake-open-catalog:v2": {
+    "daft:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "Daft supports REST catalog natively via PyIceberg integration. Configure with type=rest and the Open Catalog endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "daft:snowflake-open-catalog:v3": {
+    "daft:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "Daft V3 REST catalog support not yet documented.",
       "caveats": [
@@ -7416,18 +7425,18 @@
       ],
       "links": []
     },
-    "spark:snowflake-open-catalog:v2": {
+    "spark:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "Spark Iceberg connector supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest and the Open Catalog endpoint URI.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "spark:snowflake-open-catalog:v3": {
+    "spark:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support depends on iceberg-spark-runtime version (1.7.0+ recommended). REST catalog connectivity unchanged.",
       "caveats": [
@@ -7435,23 +7444,23 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "flink:snowflake-open-catalog:v2": {
+    "flink:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "Flink Iceberg connector supports REST catalog. Configure with catalog-type=rest and the Open Catalog endpoint URI.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "flink:snowflake-open-catalog:v3": {
+    "flink:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support depends on iceberg-flink-runtime version (1.7.0+ recommended). REST catalog connectivity unchanged.",
       "caveats": [
@@ -7459,25 +7468,25 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "kafka-connect:snowflake-open-catalog:v2": {
+    "kafka-connect:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Kafka Connect Iceberg sink supports REST catalog type natively. Snowflake Open Catalog implements the same REST Catalog spec as Apache Polaris.",
+      "notes": "Kafka Connect Iceberg sink supports REST catalog type natively. Snowflake Horizon Catalog implements the same REST Catalog spec as Apache Polaris.",
       "caveats": [
         "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "kafka-connect:snowflake-open-catalog:v3": {
+    "kafka-connect:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "REST catalog support unchanged for V3. V3 feature support depends on Iceberg library version bundled.",
       "caveats": [
@@ -7485,23 +7494,23 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "pyiceberg:snowflake-open-catalog:v2": {
+    "pyiceberg:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "PyIceberg has first-class REST catalog support. Configure with type=rest and the Open Catalog endpoint in pyiceberg config.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "pyiceberg:snowflake-open-catalog:v3": {
+    "pyiceberg:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "PyIceberg REST catalog support is available; V3 feature support depends on PyIceberg version (0.8.0+ recommended).",
       "caveats": [
@@ -7509,18 +7518,18 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-redshift:snowflake-open-catalog:v2": {
+    "aws-redshift:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "Amazon Redshift uses AWS Glue Data Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "Amazon Redshift uses AWS Glue Data Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "aws-redshift:snowflake-open-catalog:v3": {
+    "aws-redshift:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Redshift does not support Iceberg V3 or external REST catalogs.",
       "caveats": [],

--- a/src/data/compatibility-data.json
+++ b/src/data/compatibility-data.json
@@ -320,7 +320,7 @@
       "name": "Snowflake Horizon Catalog",
       "category": "catalog-support",
       "introducedIn": "v2",
-      "description": "Snowflake Horizon Catalog \u2014 Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
+      "description": "Snowflake Horizon Catalog — Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
     },
     {
       "id": "hadoop-catalog",
@@ -7156,7 +7156,7 @@
       "level": "partial",
       "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
       "caveats": [
-        "Read-only \u2014 write operations not supported via Athena",
+        "Read-only — write operations not supported via Athena",
         "Requires AWS Glue Catalog Federation configuration",
         "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
       ],
@@ -7197,7 +7197,7 @@
     },
     "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint.",
       "caveats": [],
       "links": [
         {
@@ -7272,7 +7272,7 @@
     },
     "google-dataproc:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Dataproc runs Spark and supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "notes": "Dataproc runs Spark and supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint.",
       "caveats": [],
       "links": [
         {
@@ -7307,10 +7307,22 @@
       "links": []
     },
     "azure-fabric:snowflake-horizon-catalog:v2": {
-      "level": "none",
-      "notes": "Azure Fabric uses its own OneLake catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
-      "caveats": [],
-      "links": []
+      "level": "partial",
+      "notes": "Microsoft OneLake and Snowflake interoperability is generally available (Feb 2026). Fabric can bidirectionally read Iceberg data managed by Snowflake via Horizon Catalog, and Snowflake-managed Iceberg tables can be natively stored in OneLake. Write access from Fabric engines to Snowflake-managed Iceberg tables via Horizon Catalog is not supported.",
+      "caveats": [
+        "Read interop is GA; write from Fabric to Snowflake-managed Iceberg not supported via Horizon Catalog",
+        "Requires OneLake Snowflake item configuration"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
+        },
+        {
+          "label": "Microsoft OneLake and Snowflake interoperability (GA)",
+          "url": "https://blog.fabric.microsoft.com/en-GB/blog/microsoft-onelake-and-snowflake-interoperability-is-now-generally-available/"
+        }
+      ]
     },
     "azure-fabric:snowflake-horizon-catalog:v3": {
       "level": "none",
@@ -7320,9 +7332,9 @@
     },
     "databricks:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Databricks can connect to Snowflake Horizon Catalog via ICEBERG_REST catalog integration for read access. Databricks does not support writes to externally managed Iceberg tables \u2014 this is a Databricks engine limitation, not a Horizon Catalog limitation. Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog.",
+      "notes": "Databricks can connect to Snowflake Horizon Catalog via ICEBERG_REST catalog integration for read access. Databricks does not support writes to externally managed Iceberg tables — this is a Databricks engine limitation, not a Horizon Catalog limitation. Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog.",
       "caveats": [
-        "Read-only \u2014 Databricks does not support writes to externally managed Iceberg tables (Databricks engine limitation)",
+        "Read-only — Databricks does not support writes to externally managed Iceberg tables (Databricks engine limitation)",
         "Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog",
         "Managed Iceberg tables in Databricks are in Public Preview (requires DBR 16.4 LTS+)"
       ],
@@ -7334,16 +7346,23 @@
       ]
     },
     "databricks:snowflake-horizon-catalog:v3": {
-      "level": "unknown",
-      "notes": "V3 support for Databricks connecting to Snowflake Horizon Catalog not yet documented.",
+      "level": "partial",
+      "notes": "Databricks can read Iceberg V3 tables via the Horizon Catalog REST API; however, Databricks does not support the full V3 spec. Tables using V3-only features such as nanosecond timestamps or deletion vectors may fail to read. Write support is not available — this is a Databricks engine limitation, not a Horizon Catalog limitation.",
       "caveats": [
-        "V3 cross-catalog support not yet documented"
+        "Read-only — Databricks does not support writes to externally managed Iceberg tables (Databricks engine limitation)",
+        "Tables using V3-only features (nanosecond timestamps, deletion vectors) may fail to read",
+        "Databricks does not support the full Iceberg V3 spec"
       ],
-      "links": []
+      "links": [
+        {
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
+        }
+      ]
     },
     "snowflake:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Native integration \u2014 Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Horizon Catalog as the REST endpoint.",
+      "notes": "Native integration — Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Horizon Catalog as the REST endpoint.",
       "caveats": [],
       "links": [
         {
@@ -7367,7 +7386,7 @@
     },
     "duckdb:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "DuckDB Iceberg extension supports REST catalog for reads and writes. Configure with ATTACH using the Open Catalog REST endpoint.",
+      "notes": "DuckDB Iceberg extension supports REST catalog for reads and writes. Configure with ATTACH using the Horizon Catalog REST endpoint.",
       "caveats": [],
       "links": [
         {
@@ -7378,7 +7397,7 @@
     },
     "duckdb:snowflake-horizon-catalog:v3": {
       "level": "unknown",
-      "notes": "DuckDB V3 Iceberg table support is partial; REST catalog connectivity to Open Catalog is not yet explicitly documented for V3.",
+      "notes": "DuckDB V3 Iceberg table support is partial; REST catalog connectivity to Horizon Catalog is not yet explicitly documented for V3.",
       "caveats": [
         "V3 catalog support via DuckDB not yet documented"
       ],
@@ -7408,7 +7427,7 @@
     },
     "daft:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Daft supports REST catalog natively via PyIceberg integration. Configure with type=rest and the Open Catalog endpoint.",
+      "notes": "Daft supports REST catalog natively via PyIceberg integration. Configure with type=rest and the Horizon Catalog endpoint.",
       "caveats": [],
       "links": [
         {
@@ -7427,7 +7446,7 @@
     },
     "spark:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Spark Iceberg connector supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest and the Open Catalog endpoint URI.",
+      "notes": "Spark Iceberg connector supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest and the Horizon Catalog endpoint URI.",
       "caveats": [],
       "links": [
         {
@@ -7451,7 +7470,7 @@
     },
     "flink:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Flink Iceberg connector supports REST catalog. Configure with catalog-type=rest and the Open Catalog endpoint URI.",
+      "notes": "Flink Iceberg connector supports REST catalog. Configure with catalog-type=rest and the Horizon Catalog endpoint URI.",
       "caveats": [],
       "links": [
         {
@@ -7477,7 +7496,7 @@
       "level": "partial",
       "notes": "Kafka Connect Iceberg sink supports REST catalog type natively. Snowflake Horizon Catalog implements the same REST Catalog spec as Apache Polaris.",
       "caveats": [
-        "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
+        "Not explicitly documented for Horizon Catalog specifically; works through REST Catalog compatibility"
       ],
       "links": [
         {
@@ -7490,7 +7509,7 @@
       "level": "partial",
       "notes": "REST catalog support unchanged for V3. V3 feature support depends on Iceberg library version bundled.",
       "caveats": [
-        "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
+        "Not explicitly documented for Horizon Catalog specifically; works through REST Catalog compatibility"
       ],
       "links": [
         {
@@ -7501,7 +7520,7 @@
     },
     "pyiceberg:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "PyIceberg has first-class REST catalog support. Configure with type=rest and the Open Catalog endpoint in pyiceberg config.",
+      "notes": "PyIceberg has first-class REST catalog support. Configure with type=rest and the Horizon Catalog endpoint in pyiceberg config.",
       "caveats": [],
       "links": [
         {

--- a/src/data/compatibility-data.json
+++ b/src/data/compatibility-data.json
@@ -7154,11 +7154,10 @@
     },
     "aws-athena:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
+      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported — this is an Athena engine limitation, not a Horizon Catalog or Glue Catalog Federation limitation.",
       "caveats": [
-        "Read-only — write operations not supported via Athena",
-        "Requires AWS Glue Catalog Federation configuration",
-        "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
+        "Read-only — write operations to external catalogs not supported by Athena",
+        "Requires AWS Glue Catalog Federation configuration"
       ],
       "links": [
         {
@@ -7169,16 +7168,17 @@
     },
     "aws-athena:snowflake-horizon-catalog:v3": {
       "level": "none",
-      "notes": "Athena does not support external REST catalogs.",
+      "notes": "Athena does not support Iceberg V3 tables. This is an Athena engine limitation, not a Glue Catalog Federation or Horizon Catalog limitation. Athena supports Horizon Catalog for reads on V2 tables via Glue Catalog Federation.",
       "caveats": [],
       "links": []
     },
     "aws-glue:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as an external REST catalog. Read access is supported. Write access to externally-managed tables is not supported — Glue Spark only supports writes to Glue Data Catalog natively. This is a Glue engine limitation and does not apply to OSS Spark.",
       "caveats": [
-        "Requires bundling Iceberg REST catalog dependency in Glue job",
-        "Not a native Glue catalog integration"
+        "Read-only — Glue Spark only supports writes to Glue Data Catalog natively",
+        "Write limitation is a Glue engine limitation, not a Horizon Catalog limitation",
+        "Requires bundling Iceberg REST catalog dependency in Glue job"
       ],
       "links": [
         {
@@ -7197,8 +7197,11 @@
     },
     "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint.",
-      "caveats": [],
+      "notes": "EMR Spark natively supports the Iceberg REST catalog spec via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint. Direct REST catalog connections support both reads and writes. Note: when routing through AWS Glue Catalog Federation, writes are not supported — that is a Glue/EMR federation path limitation, not an OSS Spark or Horizon Catalog limitation.",
+      "caveats": [
+        "Write via direct REST catalog API is supported",
+        "Write via Glue Catalog Federation path is not supported (Glue engine limitation)"
+      ],
       "links": [
         {
           "label": "Snowflake Horizon Catalog docs",
@@ -7543,14 +7546,17 @@
       ]
     },
     "aws-redshift:snowflake-horizon-catalog:v2": {
-      "level": "none",
-      "notes": "Amazon Redshift uses AWS Glue Data Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
-      "caveats": [],
+      "level": "unknown",
+      "notes": "Redshift Spectrum may be able to read Snowflake-managed Iceberg V2 tables via AWS Glue Catalog Federation, similar to Athena. This has not been confirmed. Write access is not expected to be supported.",
+      "caveats": [
+        "Unconfirmed — based on Glue Catalog Federation pattern used by Athena",
+        "Write operations to external catalogs are not supported by Redshift Spectrum"
+      ],
       "links": []
     },
     "aws-redshift:snowflake-horizon-catalog:v3": {
       "level": "none",
-      "notes": "Redshift does not support Iceberg V3 or external REST catalogs.",
+      "notes": "Redshift does not support Iceberg V3 tables. This is a Redshift engine limitation.",
       "caveats": [],
       "links": []
     }

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -183,11 +183,11 @@
       "description": "Databricks Unity Catalog providing unified governance for data and AI assets, with Iceberg REST Catalog API support"
     },
     {
-      "id": "snowflake-open-catalog",
-      "name": "Snowflake Open Catalog",
+      "id": "snowflake-horizon-catalog",
+      "name": "Snowflake Horizon Catalog",
       "category": "catalog-support",
       "introducedIn": "v2",
-      "description": "Snowflake Open Catalog \u2014 Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
+      "description": "Snowflake Horizon Catalog \u2014 Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
     },
     {
       "id": "hadoop-catalog",

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -183,6 +183,13 @@
       "description": "Databricks Unity Catalog providing unified governance for data and AI assets, with Iceberg REST Catalog API support"
     },
     {
+      "id": "snowflake-open-catalog",
+      "name": "Snowflake Open Catalog",
+      "category": "catalog-support",
+      "introducedIn": "v2",
+      "description": "Snowflake Open Catalog \u2014 Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
+    },
+    {
       "id": "hadoop-catalog",
       "name": "Hadoop Catalog",
       "category": "catalog-support",

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -187,7 +187,7 @@
       "name": "Snowflake Horizon Catalog",
       "category": "catalog-support",
       "introducedIn": "v2",
-      "description": "Snowflake Horizon Catalog \u2014 Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
+      "description": "Snowflake Horizon Catalog — Snowflake's managed catalog service based on Apache Polaris, implementing the Iceberg REST Catalog API with cross-engine RBAC and fine-grained table governance"
     },
     {
       "id": "hadoop-catalog",

--- a/src/data/platforms/aws-tables.json
+++ b/src/data/platforms/aws-tables.json
@@ -766,7 +766,7 @@
       "notes": "V3 support available when bundling iceberg-flink-runtime 1.7.0+ (which supports format-version 3). Managed Flink itself is not listed in AWS's V3 support matrix since it runs user-provided JARs",
       "caveats": [
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR (1.7.0+) for V3 support",
-        "Not listed in AWS V3 support matrix — V3 depends entirely on the Iceberg library version bundled by the user"
+        "Not listed in AWS V3 support matrix \u2014 V3 depends entirely on the Iceberg library version bundled by the user"
       ],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/"
     },
@@ -820,7 +820,7 @@
     },
     "aws-managed-flink:schema-evolution:v2": {
       "level": "partial",
-      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties — column additions, renames, drops, reordering, and partition changes are not supported via Flink SQL DDL",
+      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column additions, renames, drops, reordering, and partition changes are not supported via Flink SQL DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column and partition schema changes not supported via Flink SQL",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
@@ -829,7 +829,7 @@
     },
     "aws-managed-flink:schema-evolution:v3": {
       "level": "partial",
-      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties — column and partition changes not supported via Flink SQL DDL",
+      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column and partition changes not supported via Flink SQL DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column and partition schema changes not supported via Flink SQL",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR (1.7.0+) for V3 support"
@@ -935,7 +935,7 @@
     },
     "aws-managed-flink:table-maintenance:v2": {
       "level": "partial",
-      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests — use Spark for full maintenance",
+      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests \u2014 use Spark for full maintenance",
       "caveats": [
         "Only rewrite files action available; expire_snapshots, remove_orphan_files, rewrite_manifests not supported",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
@@ -2033,6 +2033,103 @@
       "level": "unknown",
       "notes": "Lineage tracking support with S3 Tables not explicitly documented",
       "caveats": []
+    },
+    "aws-athena:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Athena uses AWS Glue Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-athena:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Athena does not support external REST catalogs.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-emr:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-emr:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support via EMR Spark requires iceberg-spark-runtime 1.7.0+.",
+      "caveats": [
+        "Requires iceberg-spark-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-glue:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Open Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "caveats": [
+        "Requires bundling Iceberg REST catalog dependency in Glue job",
+        "Not a native Glue catalog integration"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-glue:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "V3 support via Glue Spark depends on Iceberg library version used; REST catalog connectivity pattern unchanged.",
+      "caveats": [
+        "V3 support depends on Iceberg library version bundled in Glue job"
+      ],
+      "links": []
+    },
+    "aws-managed-flink:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Amazon Managed Flink can connect to Snowflake Open Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
+      "caveats": [
+        "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-managed-flink:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support requires bundling iceberg-flink-runtime 1.7.0+. REST catalog connectivity unchanged.",
+      "caveats": [
+        "Requires iceberg-flink-runtime 1.7.0+ for V3 table support",
+        "Iceberg is not a pre-built connector"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-redshift-s3:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Redshift with S3 Tables uses the S3 Tables built-in catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-redshift-s3:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Redshift does not support Iceberg V3 with S3 Tables.",
+      "caveats": [],
+      "links": []
     }
   }
 }

--- a/src/data/platforms/aws-tables.json
+++ b/src/data/platforms/aws-tables.json
@@ -2034,30 +2034,39 @@
       "notes": "Lineage tracking support with S3 Tables not explicitly documented",
       "caveats": []
     },
-    "aws-athena:snowflake-open-catalog:v2": {
-      "level": "none",
-      "notes": "Athena uses AWS Glue Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
-      "caveats": [],
-      "links": []
+    "aws-athena:snowflake-horizon-catalog:v2": {
+      "level": "partial",
+      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
+      "caveats": [
+        "Read-only \u2014 write operations not supported via Athena",
+        "Requires AWS Glue Catalog Federation configuration",
+        "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
+        }
+      ]
     },
-    "aws-athena:snowflake-open-catalog:v3": {
+    "aws-athena:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Athena does not support external REST catalogs.",
       "caveats": [],
       "links": []
     },
-    "aws-emr:snowflake-open-catalog:v2": {
+    "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-emr:snowflake-open-catalog:v3": {
+    "aws-emr:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support via EMR Spark requires iceberg-spark-runtime 1.7.0+.",
       "caveats": [
@@ -2065,26 +2074,26 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-glue:snowflake-open-catalog:v2": {
+    "aws-glue:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "AWS Glue Spark jobs can connect to Snowflake Open Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
       "caveats": [
         "Requires bundling Iceberg REST catalog dependency in Glue job",
         "Not a native Glue catalog integration"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-glue:snowflake-open-catalog:v3": {
+    "aws-glue:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "V3 support via Glue Spark depends on Iceberg library version used; REST catalog connectivity pattern unchanged.",
       "caveats": [
@@ -2092,20 +2101,20 @@
       ],
       "links": []
     },
-    "aws-managed-flink:snowflake-open-catalog:v2": {
+    "aws-managed-flink:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Amazon Managed Flink can connect to Snowflake Open Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
+      "notes": "Amazon Managed Flink can connect to Snowflake Horizon Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
       "caveats": [
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-managed-flink:snowflake-open-catalog:v3": {
+    "aws-managed-flink:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support requires bundling iceberg-flink-runtime 1.7.0+. REST catalog connectivity unchanged.",
       "caveats": [
@@ -2114,18 +2123,18 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-redshift-s3:snowflake-open-catalog:v2": {
+    "aws-redshift-s3:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "Redshift with S3 Tables uses the S3 Tables built-in catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "Redshift with S3 Tables uses the S3 Tables built-in catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "aws-redshift-s3:snowflake-open-catalog:v3": {
+    "aws-redshift-s3:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Redshift does not support Iceberg V3 with S3 Tables.",
       "caveats": [],

--- a/src/data/platforms/aws-tables.json
+++ b/src/data/platforms/aws-tables.json
@@ -766,7 +766,7 @@
       "notes": "V3 support available when bundling iceberg-flink-runtime 1.7.0+ (which supports format-version 3). Managed Flink itself is not listed in AWS's V3 support matrix since it runs user-provided JARs",
       "caveats": [
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR (1.7.0+) for V3 support",
-        "Not listed in AWS V3 support matrix \u2014 V3 depends entirely on the Iceberg library version bundled by the user"
+        "Not listed in AWS V3 support matrix — V3 depends entirely on the Iceberg library version bundled by the user"
       ],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/"
     },
@@ -820,7 +820,7 @@
     },
     "aws-managed-flink:schema-evolution:v2": {
       "level": "partial",
-      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column additions, renames, drops, reordering, and partition changes are not supported via Flink SQL DDL",
+      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties — column additions, renames, drops, reordering, and partition changes are not supported via Flink SQL DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column and partition schema changes not supported via Flink SQL",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
@@ -829,7 +829,7 @@
     },
     "aws-managed-flink:schema-evolution:v3": {
       "level": "partial",
-      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column and partition changes not supported via Flink SQL DDL",
+      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties — column and partition changes not supported via Flink SQL DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column and partition schema changes not supported via Flink SQL",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR (1.7.0+) for V3 support"
@@ -935,7 +935,7 @@
     },
     "aws-managed-flink:table-maintenance:v2": {
       "level": "partial",
-      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests \u2014 use Spark for full maintenance",
+      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests — use Spark for full maintenance",
       "caveats": [
         "Only rewrite files action available; expire_snapshots, remove_orphan_files, rewrite_manifests not supported",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
@@ -2038,7 +2038,7 @@
       "level": "partial",
       "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
       "caveats": [
-        "Read-only \u2014 write operations not supported via Athena",
+        "Read-only — write operations not supported via Athena",
         "Requires AWS Glue Catalog Federation configuration",
         "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
       ],
@@ -2057,7 +2057,7 @@
     },
     "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint.",
       "caveats": [],
       "links": [
         {

--- a/src/data/platforms/aws-tables.json
+++ b/src/data/platforms/aws-tables.json
@@ -2036,11 +2036,10 @@
     },
     "aws-athena:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
+      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported — this is an Athena engine limitation, not a Horizon Catalog or Glue Catalog Federation limitation.",
       "caveats": [
-        "Read-only — write operations not supported via Athena",
-        "Requires AWS Glue Catalog Federation configuration",
-        "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
+        "Read-only — write operations to external catalogs not supported by Athena",
+        "Requires AWS Glue Catalog Federation configuration"
       ],
       "links": [
         {
@@ -2051,14 +2050,17 @@
     },
     "aws-athena:snowflake-horizon-catalog:v3": {
       "level": "none",
-      "notes": "Athena does not support external REST catalogs.",
+      "notes": "Athena does not support Iceberg V3 tables. This is an Athena engine limitation, not a Glue Catalog Federation or Horizon Catalog limitation. Athena supports Horizon Catalog for reads on V2 tables via Glue Catalog Federation.",
       "caveats": [],
       "links": []
     },
     "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint.",
-      "caveats": [],
+      "notes": "EMR Spark natively supports the Iceberg REST catalog spec via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint. Direct REST catalog connections support both reads and writes. Note: when routing through AWS Glue Catalog Federation, writes are not supported — that is a Glue/EMR federation path limitation, not an OSS Spark or Horizon Catalog limitation.",
+      "caveats": [
+        "Write via direct REST catalog API is supported",
+        "Write via Glue Catalog Federation path is not supported (Glue engine limitation)"
+      ],
       "links": [
         {
           "label": "Snowflake Horizon Catalog docs",
@@ -2081,10 +2083,11 @@
     },
     "aws-glue:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as an external REST catalog. Read access is supported. Write access to externally-managed tables is not supported — Glue Spark only supports writes to Glue Data Catalog natively. This is a Glue engine limitation and does not apply to OSS Spark.",
       "caveats": [
-        "Requires bundling Iceberg REST catalog dependency in Glue job",
-        "Not a native Glue catalog integration"
+        "Read-only — Glue Spark only supports writes to Glue Data Catalog natively",
+        "Write limitation is a Glue engine limitation, not a Horizon Catalog limitation",
+        "Requires bundling Iceberg REST catalog dependency in Glue job"
       ],
       "links": [
         {
@@ -2129,14 +2132,17 @@
       ]
     },
     "aws-redshift-s3:snowflake-horizon-catalog:v2": {
-      "level": "none",
-      "notes": "Redshift with S3 Tables uses the S3 Tables built-in catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
-      "caveats": [],
+      "level": "unknown",
+      "notes": "Redshift Spectrum may be able to read Snowflake-managed Iceberg V2 tables via AWS Glue Catalog Federation, similar to Athena. This has not been confirmed. Write access is not expected to be supported.",
+      "caveats": [
+        "Unconfirmed — based on Glue Catalog Federation pattern used by Athena",
+        "Write operations to external catalogs are not supported by Redshift Spectrum"
+      ],
       "links": []
     },
     "aws-redshift-s3:snowflake-horizon-catalog:v3": {
       "level": "none",
-      "notes": "Redshift does not support Iceberg V3 with S3 Tables.",
+      "notes": "Redshift does not support Iceberg V3 tables. This is a Redshift engine limitation.",
       "caveats": [],
       "links": []
     }

--- a/src/data/platforms/aws.json
+++ b/src/data/platforms/aws.json
@@ -2944,11 +2944,10 @@
     },
     "aws-athena:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
+      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported — this is an Athena engine limitation, not a Horizon Catalog or Glue Catalog Federation limitation.",
       "caveats": [
-        "Read-only — write operations not supported via Athena",
-        "Requires AWS Glue Catalog Federation configuration",
-        "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
+        "Read-only — write operations to external catalogs not supported by Athena",
+        "Requires AWS Glue Catalog Federation configuration"
       ],
       "links": [
         {
@@ -2959,14 +2958,17 @@
     },
     "aws-athena:snowflake-horizon-catalog:v3": {
       "level": "none",
-      "notes": "Athena does not support external REST catalogs.",
+      "notes": "Athena does not support Iceberg V3 tables. This is an Athena engine limitation, not a Glue Catalog Federation or Horizon Catalog limitation. Athena supports Horizon Catalog for reads on V2 tables via Glue Catalog Federation.",
       "caveats": [],
       "links": []
     },
     "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint.",
-      "caveats": [],
+      "notes": "EMR Spark natively supports the Iceberg REST catalog spec via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint. Direct REST catalog connections support both reads and writes. Note: when routing through AWS Glue Catalog Federation, writes are not supported — that is a Glue/EMR federation path limitation, not an OSS Spark or Horizon Catalog limitation.",
+      "caveats": [
+        "Write via direct REST catalog API is supported",
+        "Write via Glue Catalog Federation path is not supported (Glue engine limitation)"
+      ],
       "links": [
         {
           "label": "Snowflake Horizon Catalog docs",
@@ -2989,10 +2991,11 @@
     },
     "aws-glue:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as an external REST catalog. Read access is supported. Write access to externally-managed tables is not supported — Glue Spark only supports writes to Glue Data Catalog natively. This is a Glue engine limitation and does not apply to OSS Spark.",
       "caveats": [
-        "Requires bundling Iceberg REST catalog dependency in Glue job",
-        "Not a native Glue catalog integration"
+        "Read-only — Glue Spark only supports writes to Glue Data Catalog natively",
+        "Write limitation is a Glue engine limitation, not a Horizon Catalog limitation",
+        "Requires bundling Iceberg REST catalog dependency in Glue job"
       ],
       "links": [
         {
@@ -3037,14 +3040,17 @@
       ]
     },
     "aws-redshift-s3:snowflake-horizon-catalog:v2": {
-      "level": "none",
-      "notes": "Redshift with S3 Tables uses the S3 Tables built-in catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
-      "caveats": [],
+      "level": "unknown",
+      "notes": "Redshift Spectrum may be able to read Snowflake-managed Iceberg V2 tables via AWS Glue Catalog Federation, similar to Athena. This has not been confirmed. Write access is not expected to be supported.",
+      "caveats": [
+        "Unconfirmed — based on Glue Catalog Federation pattern used by Athena",
+        "Write operations to external catalogs are not supported by Redshift Spectrum"
+      ],
       "links": []
     },
     "aws-redshift-s3:snowflake-horizon-catalog:v3": {
       "level": "none",
-      "notes": "Redshift does not support Iceberg V3 with S3 Tables.",
+      "notes": "Redshift does not support Iceberg V3 tables. This is a Redshift engine limitation.",
       "caveats": [],
       "links": []
     }

--- a/src/data/platforms/aws.json
+++ b/src/data/platforms/aws.json
@@ -338,7 +338,7 @@
       "notes": "V3 support available when bundling iceberg-flink-runtime 1.7.0+ (which supports format-version 3). Managed Flink itself is not listed in AWS's V3 support matrix since it runs user-provided JARs",
       "caveats": [
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR (1.7.0+) for V3 support",
-        "Not listed in AWS V3 support matrix \u2014 V3 depends entirely on the Iceberg library version bundled by the user"
+        "Not listed in AWS V3 support matrix — V3 depends entirely on the Iceberg library version bundled by the user"
       ],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/"
     },
@@ -392,7 +392,7 @@
     },
     "aws-managed-flink:schema-evolution:v2": {
       "level": "partial",
-      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column additions, renames, drops, reordering, and partition changes are not supported via Flink SQL DDL",
+      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties — column additions, renames, drops, reordering, and partition changes are not supported via Flink SQL DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column and partition schema changes not supported via Flink SQL",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
@@ -401,7 +401,7 @@
     },
     "aws-managed-flink:schema-evolution:v3": {
       "level": "partial",
-      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column and partition changes not supported via Flink SQL DDL",
+      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties — column and partition changes not supported via Flink SQL DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column and partition schema changes not supported via Flink SQL",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR (1.7.0+) for V3 support"
@@ -507,7 +507,7 @@
     },
     "aws-managed-flink:table-maintenance:v2": {
       "level": "partial",
-      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests \u2014 use Spark for full maintenance",
+      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests — use Spark for full maintenance",
       "caveats": [
         "Only rewrite files action available; expire_snapshots, remove_orphan_files, rewrite_manifests not supported",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
@@ -1945,7 +1945,7 @@
       "notes": "Full table maintenance for V3 tables; automatic optimization via Glue Data Catalog compacts deletion vector files and removes old V2 delete files after upgrade",
       "caveats": [
         "Requires Glue 5.0+ for V3 format support",
-        "First compaction after V2\u2192V3 upgrade removes old positional/equality delete files"
+        "First compaction after V2→V3 upgrade removes old positional/equality delete files"
       ],
       "links": [
         {
@@ -1959,7 +1959,7 @@
       "notes": "Full table maintenance for V3 tables; automatic optimization via Glue Data Catalog compacts deletion vector files and removes old V2 delete files after upgrade",
       "caveats": [
         "Requires Glue 5.0+ for V3 format support",
-        "First compaction after V2\u2192V3 upgrade removes old positional/equality delete files"
+        "First compaction after V2→V3 upgrade removes old positional/equality delete files"
       ],
       "links": [
         {
@@ -1970,10 +1970,10 @@
     },
     "aws-emr:branching-tagging:v2": {
       "level": "full",
-      "notes": "Supported via Spark on EMR. Glue: Branching and tagging require Iceberg \u22651.2.0; only available natively on Glue 5.0+ (Iceberg 1.7.1) or via custom JARs on Glue 4.0",
+      "notes": "Supported via Spark on EMR. Glue: Branching and tagging require Iceberg ≥1.2.0; only available natively on Glue 5.0+ (Iceberg 1.7.1) or via custom JARs on Glue 4.0",
       "caveats": [
         "Not available on Glue 3.0 or Glue 4.0 with native Iceberg (0.13.1 / 1.0.0)",
-        "Requires Glue 5.0+ or custom Iceberg JARs \u22651.2.0"
+        "Requires Glue 5.0+ or custom Iceberg JARs ≥1.2.0"
       ],
       "links": [
         {
@@ -1984,10 +1984,10 @@
     },
     "aws-glue:branching-tagging:v2": {
       "level": "full",
-      "notes": "Supported via Glue ETL. Glue: Branching and tagging require Iceberg \u22651.2.0; only available natively on Glue 5.0+ (Iceberg 1.7.1) or via custom JARs on Glue 4.0",
+      "notes": "Supported via Glue ETL. Glue: Branching and tagging require Iceberg ≥1.2.0; only available natively on Glue 5.0+ (Iceberg 1.7.1) or via custom JARs on Glue 4.0",
       "caveats": [
         "Not available on Glue 3.0 or Glue 4.0 with native Iceberg (0.13.1 / 1.0.0)",
-        "Requires Glue 5.0+ or custom Iceberg JARs \u22651.2.0"
+        "Requires Glue 5.0+ or custom Iceberg JARs ≥1.2.0"
       ],
       "links": [
         {
@@ -2556,10 +2556,10 @@
     },
     "aws-emr:table-creation:v3": {
       "level": "full",
-      "notes": "Create V3 tables via Spark SQL DDL with format-version=3 on Glue 5.0+; upgrade V2\u2192V3 via ALTER TABLE SET TBLPROPERTIES",
+      "notes": "Create V3 tables via Spark SQL DDL with format-version=3 on Glue 5.0+; upgrade V2→V3 via ALTER TABLE SET TBLPROPERTIES",
       "caveats": [
         "Requires Glue 5.0+ for V3 format support",
-        "V2\u2192V3 upgrade is one-way; cannot downgrade back to V2"
+        "V2→V3 upgrade is one-way; cannot downgrade back to V2"
       ],
       "links": [
         {
@@ -2570,10 +2570,10 @@
     },
     "aws-glue:table-creation:v3": {
       "level": "full",
-      "notes": "Create V3 tables via Spark SQL DDL with format-version=3 on Glue 5.0+; upgrade V2\u2192V3 via ALTER TABLE SET TBLPROPERTIES",
+      "notes": "Create V3 tables via Spark SQL DDL with format-version=3 on Glue 5.0+; upgrade V2→V3 via ALTER TABLE SET TBLPROPERTIES",
       "caveats": [
         "Requires Glue 5.0+ for V3 format support",
-        "V2\u2192V3 upgrade is one-way; cannot downgrade back to V2"
+        "V2→V3 upgrade is one-way; cannot downgrade back to V2"
       ],
       "links": [
         {
@@ -2707,7 +2707,7 @@
       "notes": "V3 row lineage enables row-level change tracking via _row_id and _last_updated_sequence_number fields; requires Glue 5.1 (Iceberg 1.10.0) for full support. EMR: CDC support available via Spark streaming on AWS EMR",
       "caveats": [
         "Requires Glue 5.1 (Iceberg 1.10.0) for row lineage",
-        "No historical backfill of row lineage after V2\u2192V3 upgrade",
+        "No historical backfill of row lineage after V2→V3 upgrade",
         "Requires streaming configuration"
       ],
       "links": [
@@ -2722,7 +2722,7 @@
       "notes": "V3 row lineage enables row-level change tracking via _row_id and _last_updated_sequence_number fields; requires Glue 5.1 (Iceberg 1.10.0) for full support. EMR: CDC support available via Spark streaming on AWS EMR",
       "caveats": [
         "Requires Glue 5.1 (Iceberg 1.10.0) for row lineage",
-        "No historical backfill of row lineage after V2\u2192V3 upgrade",
+        "No historical backfill of row lineage after V2→V3 upgrade",
         "Requires streaming configuration"
       ],
       "links": [
@@ -2747,7 +2747,7 @@
       "notes": "V3 row lineage provides _row_id and _last_updated_sequence_number metadata fields for precise change tracking; requires Glue 5.1 (Iceberg 1.10.0). EMR: AWS EMR V3 lineage support is not yet documented",
       "caveats": [
         "Requires Glue 5.1 (Iceberg 1.10.0)",
-        "No historical backfill after V2\u2192V3 upgrade"
+        "No historical backfill after V2→V3 upgrade"
       ],
       "links": [
         {
@@ -2761,7 +2761,7 @@
       "notes": "V3 row lineage provides _row_id and _last_updated_sequence_number metadata fields for precise change tracking; requires Glue 5.1 (Iceberg 1.10.0). EMR: AWS EMR V3 lineage support is not yet documented",
       "caveats": [
         "Requires Glue 5.1 (Iceberg 1.10.0)",
-        "No historical backfill after V2\u2192V3 upgrade"
+        "No historical backfill after V2→V3 upgrade"
       ],
       "links": [
         {
@@ -2889,7 +2889,7 @@
           "url": "https://aws.amazon.com/blogs/big-data/use-aws-glue-etl-to-perform-merge-partition-evolution-and-schema-evolution-on-apache-iceberg/"
         },
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -2907,7 +2907,7 @@
           "url": "https://aws.amazon.com/blogs/big-data/use-aws-glue-etl-to-perform-merge-partition-evolution-and-schema-evolution-on-apache-iceberg/"
         },
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -2922,7 +2922,7 @@
           "url": "https://aws.amazon.com/blogs/big-data/use-aws-glue-etl-to-perform-merge-partition-evolution-and-schema-evolution-on-apache-iceberg/"
         },
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -2937,7 +2937,7 @@
           "url": "https://aws.amazon.com/blogs/big-data/use-aws-glue-etl-to-perform-merge-partition-evolution-and-schema-evolution-on-apache-iceberg/"
         },
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -2946,7 +2946,7 @@
       "level": "partial",
       "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
       "caveats": [
-        "Read-only \u2014 write operations not supported via Athena",
+        "Read-only — write operations not supported via Athena",
         "Requires AWS Glue Catalog Federation configuration",
         "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
       ],
@@ -2965,7 +2965,7 @@
     },
     "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint.",
       "caveats": [],
       "links": [
         {

--- a/src/data/platforms/aws.json
+++ b/src/data/platforms/aws.json
@@ -2942,30 +2942,39 @@
         }
       ]
     },
-    "aws-athena:snowflake-open-catalog:v2": {
-      "level": "none",
-      "notes": "Athena uses AWS Glue Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
-      "caveats": [],
-      "links": []
+    "aws-athena:snowflake-horizon-catalog:v2": {
+      "level": "partial",
+      "notes": "Athena can access Snowflake Horizon Catalog via AWS Glue Catalog Federation, enabling read-only access to Snowflake-managed Iceberg V2 tables. Write operations are not supported. The V3 limitation is an Athena engine limitation, not a Catalog Federation limitation.",
+      "caveats": [
+        "Read-only \u2014 write operations not supported via Athena",
+        "Requires AWS Glue Catalog Federation configuration",
+        "V3 limitation is an Athena engine constraint, not a Horizon Catalog constraint"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
+        }
+      ]
     },
-    "aws-athena:snowflake-open-catalog:v3": {
+    "aws-athena:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Athena does not support external REST catalogs.",
       "caveats": [],
       "links": []
     },
-    "aws-emr:snowflake-open-catalog:v2": {
+    "aws-emr:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-emr:snowflake-open-catalog:v3": {
+    "aws-emr:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support via EMR Spark requires iceberg-spark-runtime 1.7.0+.",
       "caveats": [
@@ -2973,26 +2982,26 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-glue:snowflake-open-catalog:v2": {
+    "aws-glue:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "AWS Glue Spark jobs can connect to Snowflake Open Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Horizon Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
       "caveats": [
         "Requires bundling Iceberg REST catalog dependency in Glue job",
         "Not a native Glue catalog integration"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-glue:snowflake-open-catalog:v3": {
+    "aws-glue:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "V3 support via Glue Spark depends on Iceberg library version used; REST catalog connectivity pattern unchanged.",
       "caveats": [
@@ -3000,20 +3009,20 @@
       ],
       "links": []
     },
-    "aws-managed-flink:snowflake-open-catalog:v2": {
+    "aws-managed-flink:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Amazon Managed Flink can connect to Snowflake Open Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
+      "notes": "Amazon Managed Flink can connect to Snowflake Horizon Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
       "caveats": [
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-managed-flink:snowflake-open-catalog:v3": {
+    "aws-managed-flink:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support requires bundling iceberg-flink-runtime 1.7.0+. REST catalog connectivity unchanged.",
       "caveats": [
@@ -3022,18 +3031,18 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "aws-redshift-s3:snowflake-open-catalog:v2": {
+    "aws-redshift-s3:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "Redshift with S3 Tables uses the S3 Tables built-in catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "Redshift with S3 Tables uses the S3 Tables built-in catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "aws-redshift-s3:snowflake-open-catalog:v3": {
+    "aws-redshift-s3:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Redshift does not support Iceberg V3 with S3 Tables.",
       "caveats": [],

--- a/src/data/platforms/aws.json
+++ b/src/data/platforms/aws.json
@@ -338,7 +338,7 @@
       "notes": "V3 support available when bundling iceberg-flink-runtime 1.7.0+ (which supports format-version 3). Managed Flink itself is not listed in AWS's V3 support matrix since it runs user-provided JARs",
       "caveats": [
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR (1.7.0+) for V3 support",
-        "Not listed in AWS V3 support matrix — V3 depends entirely on the Iceberg library version bundled by the user"
+        "Not listed in AWS V3 support matrix \u2014 V3 depends entirely on the Iceberg library version bundled by the user"
       ],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/"
     },
@@ -392,7 +392,7 @@
     },
     "aws-managed-flink:schema-evolution:v2": {
       "level": "partial",
-      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties — column additions, renames, drops, reordering, and partition changes are not supported via Flink SQL DDL",
+      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column additions, renames, drops, reordering, and partition changes are not supported via Flink SQL DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column and partition schema changes not supported via Flink SQL",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
@@ -401,7 +401,7 @@
     },
     "aws-managed-flink:schema-evolution:v3": {
       "level": "partial",
-      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties — column and partition changes not supported via Flink SQL DDL",
+      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column and partition changes not supported via Flink SQL DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column and partition schema changes not supported via Flink SQL",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR (1.7.0+) for V3 support"
@@ -507,7 +507,7 @@
     },
     "aws-managed-flink:table-maintenance:v2": {
       "level": "partial",
-      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests — use Spark for full maintenance",
+      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests \u2014 use Spark for full maintenance",
       "caveats": [
         "Only rewrite files action available; expire_snapshots, remove_orphan_files, rewrite_manifests not supported",
         "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
@@ -1945,7 +1945,7 @@
       "notes": "Full table maintenance for V3 tables; automatic optimization via Glue Data Catalog compacts deletion vector files and removes old V2 delete files after upgrade",
       "caveats": [
         "Requires Glue 5.0+ for V3 format support",
-        "First compaction after V2→V3 upgrade removes old positional/equality delete files"
+        "First compaction after V2\u2192V3 upgrade removes old positional/equality delete files"
       ],
       "links": [
         {
@@ -1959,7 +1959,7 @@
       "notes": "Full table maintenance for V3 tables; automatic optimization via Glue Data Catalog compacts deletion vector files and removes old V2 delete files after upgrade",
       "caveats": [
         "Requires Glue 5.0+ for V3 format support",
-        "First compaction after V2→V3 upgrade removes old positional/equality delete files"
+        "First compaction after V2\u2192V3 upgrade removes old positional/equality delete files"
       ],
       "links": [
         {
@@ -1970,10 +1970,10 @@
     },
     "aws-emr:branching-tagging:v2": {
       "level": "full",
-      "notes": "Supported via Spark on EMR. Glue: Branching and tagging require Iceberg ≥1.2.0; only available natively on Glue 5.0+ (Iceberg 1.7.1) or via custom JARs on Glue 4.0",
+      "notes": "Supported via Spark on EMR. Glue: Branching and tagging require Iceberg \u22651.2.0; only available natively on Glue 5.0+ (Iceberg 1.7.1) or via custom JARs on Glue 4.0",
       "caveats": [
         "Not available on Glue 3.0 or Glue 4.0 with native Iceberg (0.13.1 / 1.0.0)",
-        "Requires Glue 5.0+ or custom Iceberg JARs ≥1.2.0"
+        "Requires Glue 5.0+ or custom Iceberg JARs \u22651.2.0"
       ],
       "links": [
         {
@@ -1984,10 +1984,10 @@
     },
     "aws-glue:branching-tagging:v2": {
       "level": "full",
-      "notes": "Supported via Glue ETL. Glue: Branching and tagging require Iceberg ≥1.2.0; only available natively on Glue 5.0+ (Iceberg 1.7.1) or via custom JARs on Glue 4.0",
+      "notes": "Supported via Glue ETL. Glue: Branching and tagging require Iceberg \u22651.2.0; only available natively on Glue 5.0+ (Iceberg 1.7.1) or via custom JARs on Glue 4.0",
       "caveats": [
         "Not available on Glue 3.0 or Glue 4.0 with native Iceberg (0.13.1 / 1.0.0)",
-        "Requires Glue 5.0+ or custom Iceberg JARs ≥1.2.0"
+        "Requires Glue 5.0+ or custom Iceberg JARs \u22651.2.0"
       ],
       "links": [
         {
@@ -2556,10 +2556,10 @@
     },
     "aws-emr:table-creation:v3": {
       "level": "full",
-      "notes": "Create V3 tables via Spark SQL DDL with format-version=3 on Glue 5.0+; upgrade V2→V3 via ALTER TABLE SET TBLPROPERTIES",
+      "notes": "Create V3 tables via Spark SQL DDL with format-version=3 on Glue 5.0+; upgrade V2\u2192V3 via ALTER TABLE SET TBLPROPERTIES",
       "caveats": [
         "Requires Glue 5.0+ for V3 format support",
-        "V2→V3 upgrade is one-way; cannot downgrade back to V2"
+        "V2\u2192V3 upgrade is one-way; cannot downgrade back to V2"
       ],
       "links": [
         {
@@ -2570,10 +2570,10 @@
     },
     "aws-glue:table-creation:v3": {
       "level": "full",
-      "notes": "Create V3 tables via Spark SQL DDL with format-version=3 on Glue 5.0+; upgrade V2→V3 via ALTER TABLE SET TBLPROPERTIES",
+      "notes": "Create V3 tables via Spark SQL DDL with format-version=3 on Glue 5.0+; upgrade V2\u2192V3 via ALTER TABLE SET TBLPROPERTIES",
       "caveats": [
         "Requires Glue 5.0+ for V3 format support",
-        "V2→V3 upgrade is one-way; cannot downgrade back to V2"
+        "V2\u2192V3 upgrade is one-way; cannot downgrade back to V2"
       ],
       "links": [
         {
@@ -2707,7 +2707,7 @@
       "notes": "V3 row lineage enables row-level change tracking via _row_id and _last_updated_sequence_number fields; requires Glue 5.1 (Iceberg 1.10.0) for full support. EMR: CDC support available via Spark streaming on AWS EMR",
       "caveats": [
         "Requires Glue 5.1 (Iceberg 1.10.0) for row lineage",
-        "No historical backfill of row lineage after V2→V3 upgrade",
+        "No historical backfill of row lineage after V2\u2192V3 upgrade",
         "Requires streaming configuration"
       ],
       "links": [
@@ -2722,7 +2722,7 @@
       "notes": "V3 row lineage enables row-level change tracking via _row_id and _last_updated_sequence_number fields; requires Glue 5.1 (Iceberg 1.10.0) for full support. EMR: CDC support available via Spark streaming on AWS EMR",
       "caveats": [
         "Requires Glue 5.1 (Iceberg 1.10.0) for row lineage",
-        "No historical backfill of row lineage after V2→V3 upgrade",
+        "No historical backfill of row lineage after V2\u2192V3 upgrade",
         "Requires streaming configuration"
       ],
       "links": [
@@ -2747,7 +2747,7 @@
       "notes": "V3 row lineage provides _row_id and _last_updated_sequence_number metadata fields for precise change tracking; requires Glue 5.1 (Iceberg 1.10.0). EMR: AWS EMR V3 lineage support is not yet documented",
       "caveats": [
         "Requires Glue 5.1 (Iceberg 1.10.0)",
-        "No historical backfill after V2→V3 upgrade"
+        "No historical backfill after V2\u2192V3 upgrade"
       ],
       "links": [
         {
@@ -2761,7 +2761,7 @@
       "notes": "V3 row lineage provides _row_id and _last_updated_sequence_number metadata fields for precise change tracking; requires Glue 5.1 (Iceberg 1.10.0). EMR: AWS EMR V3 lineage support is not yet documented",
       "caveats": [
         "Requires Glue 5.1 (Iceberg 1.10.0)",
-        "No historical backfill after V2→V3 upgrade"
+        "No historical backfill after V2\u2192V3 upgrade"
       ],
       "links": [
         {
@@ -2889,7 +2889,7 @@
           "url": "https://aws.amazon.com/blogs/big-data/use-aws-glue-etl-to-perform-merge-partition-evolution-and-schema-evolution-on-apache-iceberg/"
         },
         {
-          "label": "Spark DDL – ALTER TABLE",
+          "label": "Spark DDL \u2013 ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -2907,7 +2907,7 @@
           "url": "https://aws.amazon.com/blogs/big-data/use-aws-glue-etl-to-perform-merge-partition-evolution-and-schema-evolution-on-apache-iceberg/"
         },
         {
-          "label": "Spark DDL – ALTER TABLE",
+          "label": "Spark DDL \u2013 ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -2922,7 +2922,7 @@
           "url": "https://aws.amazon.com/blogs/big-data/use-aws-glue-etl-to-perform-merge-partition-evolution-and-schema-evolution-on-apache-iceberg/"
         },
         {
-          "label": "Spark DDL – ALTER TABLE",
+          "label": "Spark DDL \u2013 ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -2937,10 +2937,107 @@
           "url": "https://aws.amazon.com/blogs/big-data/use-aws-glue-etl-to-perform-merge-partition-evolution-and-schema-evolution-on-apache-iceberg/"
         },
         {
-          "label": "Spark DDL – ALTER TABLE",
+          "label": "Spark DDL \u2013 ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
+    },
+    "aws-athena:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Athena uses AWS Glue Catalog exclusively and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-athena:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Athena does not support external REST catalogs.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-emr:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "EMR Spark natively supports REST catalog via iceberg-spark-runtime. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-emr:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support via EMR Spark requires iceberg-spark-runtime 1.7.0+.",
+      "caveats": [
+        "Requires iceberg-spark-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-glue:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "AWS Glue Spark jobs can connect to Snowflake Open Catalog as a REST catalog using the Iceberg REST catalog configuration. Requires additional connector setup.",
+      "caveats": [
+        "Requires bundling Iceberg REST catalog dependency in Glue job",
+        "Not a native Glue catalog integration"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-glue:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "V3 support via Glue Spark depends on Iceberg library version used; REST catalog connectivity pattern unchanged.",
+      "caveats": [
+        "V3 support depends on Iceberg library version bundled in Glue job"
+      ],
+      "links": []
+    },
+    "aws-managed-flink:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Amazon Managed Flink can connect to Snowflake Open Catalog via REST catalog when iceberg-flink-runtime JAR (1.6.0+) is bundled in the application.",
+      "caveats": [
+        "Iceberg is not a pre-built connector; users must bundle iceberg-flink-runtime JAR"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-managed-flink:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support requires bundling iceberg-flink-runtime 1.7.0+. REST catalog connectivity unchanged.",
+      "caveats": [
+        "Requires iceberg-flink-runtime 1.7.0+ for V3 table support",
+        "Iceberg is not a pre-built connector"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "aws-redshift-s3:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Redshift with S3 Tables uses the S3 Tables built-in catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-redshift-s3:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Redshift does not support Iceberg V3 with S3 Tables.",
+      "caveats": [],
+      "links": []
     }
   }
 }

--- a/src/data/platforms/azure.json
+++ b/src/data/platforms/azure.json
@@ -1442,25 +1442,25 @@
       ],
       "links": []
     },
-    "azure-synapse:snowflake-open-catalog:v2": {
+    "azure-synapse:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "Azure Synapse Analytics uses its own catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "Azure Synapse Analytics uses its own catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "azure-synapse:snowflake-open-catalog:v3": {
+    "azure-synapse:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Azure Synapse does not support external REST catalogs.",
       "caveats": [],
       "links": []
     },
-    "azure-fabric:snowflake-open-catalog:v2": {
+    "azure-fabric:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "Azure Fabric uses its own OneLake catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "Azure Fabric uses its own OneLake catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "azure-fabric:snowflake-open-catalog:v3": {
+    "azure-fabric:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Azure Fabric does not support external REST catalogs.",
       "caveats": [],

--- a/src/data/platforms/azure.json
+++ b/src/data/platforms/azure.json
@@ -325,7 +325,7 @@
       "notes": "Read support available only via Spark pools with manually installed iceberg-spark-runtime JAR; serverless SQL pool does NOT support Iceberg (only Parquet, Delta Lake, CSV); dedicated SQL pool has no Iceberg support",
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation on Spark pools",
-        "Serverless SQL pool does NOT support Iceberg — only Parquet, Delta Lake, and delimited text formats",
+        "Serverless SQL pool does NOT support Iceberg \u2014 only Parquet, Delta Lake, and delimited text formats",
         "Dedicated SQL pool has no Iceberg support",
         "Microsoft recommends migrating Synapse Spark workloads to Microsoft Fabric"
       ],
@@ -411,7 +411,7 @@
       "notes": "Standard Spark Iceberg catalogs (Hive, Hadoop, REST, JDBC) can be configured manually via Spark pool settings; no native Synapse catalog integration for Iceberg",
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation and Spark configuration",
-        "No native Synapse catalog integration for Iceberg — all catalog configuration is manual",
+        "No native Synapse catalog integration for Iceberg \u2014 all catalog configuration is manual",
         "Catalog type depends on user-supplied Spark configuration"
       ],
       "links": [
@@ -436,7 +436,7 @@
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation and Spark configuration",
         "Requires configuring spark.sql.catalog with org.apache.iceberg.spark.SparkCatalog",
-        "No native Synapse integration — standard OSS Spark Iceberg configuration"
+        "No native Synapse integration \u2014 standard OSS Spark Iceberg configuration"
       ],
       "links": [
         {
@@ -471,7 +471,7 @@
       "notes": "Iceberg REST Catalog can be configured via Spark pool settings using the standard Spark Iceberg RESTCatalog implementation",
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation and Spark configuration",
-        "No native Synapse REST catalog endpoint — must point to an external REST catalog server",
+        "No native Synapse REST catalog endpoint \u2014 must point to an external REST catalog server",
         "Standard OSS Spark Iceberg configuration applies"
       ],
       "links": [
@@ -544,7 +544,7 @@
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation and Spark configuration",
         "Uses ADLS Gen2 (abfss://) as the underlying storage; standard Hadoop catalog with ADLS connector",
-        "No native Synapse integration — standard OSS Spark Iceberg configuration"
+        "No native Synapse integration \u2014 standard OSS Spark Iceberg configuration"
       ],
       "links": [
         {
@@ -708,7 +708,7 @@
       "level": "unknown",
       "notes": "OneLake virtualizes Iceberg tables as Delta Lake using Apache XTable, which converts positional delete files during Iceberg-to-Delta conversion",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Position deletes are translated during metadata virtualization; not a native Iceberg engine"
       ],
       "links": [
@@ -739,7 +739,7 @@
       "level": "unknown",
       "notes": "Equality delete support depends on the Apache XTable virtualization layer that converts Iceberg metadata to Delta Lake format",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Equality delete handling depends on XTable conversion fidelity"
       ],
       "links": [
@@ -761,7 +761,7 @@
       "level": "unknown",
       "notes": "When reading external Iceberg tables via shortcuts, merge-on-read is handled by the XTable virtualization layer converting to Delta Lake",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Fabric uses Delta Lake merge strategies internally, not Iceberg MoR"
       ],
       "links": [
@@ -783,7 +783,7 @@
       "level": "unknown",
       "notes": "Fabric uses Delta Lake copy-on-write internally; when Delta tables are virtualized as Iceberg, the underlying CoW behavior is preserved",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "CoW is the underlying Delta Lake behavior, not native Iceberg CoW"
       ],
       "links": [
@@ -805,7 +805,7 @@
       "level": "unknown",
       "notes": "Schema evolution works on the Delta Lake side; for Iceberg shortcuts, metadata changes may not be immediately reflected until a data change occurs",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Iceberg metadata changes (add/drop/rename columns) may require a data change to trigger re-conversion"
       ],
       "links": [
@@ -855,7 +855,7 @@
       "level": "unknown",
       "notes": "Iceberg hidden partitioning is preserved when reading via OneLake shortcuts; Fabric creates Delta partitioned tables natively, which are virtualized as Iceberg",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Partitioning is translated between formats during virtualization"
       ],
       "links": [
@@ -877,7 +877,7 @@
       "level": "unknown",
       "notes": "Partition evolution support depends on the metadata virtualization layer; may have limitations compared to native Iceberg partition evolution",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Partition evolution may not fully round-trip through Delta-Iceberg virtualization"
       ],
       "links": [
@@ -913,7 +913,7 @@
       "level": "unknown",
       "notes": "Time travel is available on Delta Lake tables within Fabric; for Iceberg shortcuts virtualized as Delta, time travel operates on the Delta log, not Iceberg snapshots",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Time travel operates on virtualized Delta log, not native Iceberg snapshot history"
       ],
       "links": [
@@ -935,7 +935,7 @@
       "level": "unknown",
       "notes": "Fabric provides automatic optimization (compaction, V-Order) for Delta Lake tables; for Iceberg shortcuts, maintenance must be performed by the source Iceberg writer",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Auto-optimization applies to Delta tables only; Iceberg shortcuts require external maintenance"
       ],
       "links": [
@@ -1007,7 +1007,7 @@
       "level": "unknown",
       "notes": "Fabric writes Delta Lake tables natively, which are auto-virtualized as Iceberg for external readers. External tools (e.g., Snowflake) can write Iceberg tables directly to OneLake. Fabric itself does not write native Iceberg format.",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Fabric engines write Delta Lake, not native Iceberg; external Iceberg writers (Snowflake) can write directly to OneLake"
       ],
       "links": [
@@ -1033,7 +1033,7 @@
       "level": "unknown",
       "notes": "DML operations (MERGE, UPDATE, DELETE) operate on Delta Lake tables within Fabric; changes are reflected in the virtualized Iceberg view. No native Iceberg DML from Fabric engines.",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "DML is Delta Lake-based; Iceberg view is read-only from Fabric perspective"
       ],
       "links": [
@@ -1202,7 +1202,7 @@
       "level": "unknown",
       "notes": "Fabric creates Delta Lake tables (via Spark notebooks, pipelines, etc.) that are automatically virtualized as Iceberg for external readers. External writers (e.g., Snowflake) can create Iceberg tables directly in OneLake.",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Native Iceberg table creation only via external writers (e.g., Snowflake); Fabric creates Delta tables virtualized as Iceberg"
       ],
       "links": [
@@ -1359,7 +1359,7 @@
       "level": "unknown",
       "notes": "When Fabric virtualizes Delta Lake tables as Iceberg via Apache XTable, column statistics are translated from Delta Lake statistics to Iceberg manifest statistics. For external Iceberg tables read via OneLake shortcuts, existing statistics are preserved.",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
         "Statistics quality depends on the Delta-to-Iceberg virtualization fidelity"
       ],
       "links": [
@@ -1381,7 +1381,7 @@
       "level": "unknown",
       "notes": "Fabric does not support Iceberg bloom filters. Delta Lake tables virtualized as Iceberg do not include bloom filter metadata in the Iceberg representation.",
       "caveats": [
-        "Iceberg support is via metadata virtualization — Fabric natively uses Delta Lake, not Iceberg"
+        "Iceberg support is via metadata virtualization \u2014 Fabric natively uses Delta Lake, not Iceberg"
       ],
       "links": [
         {
@@ -1407,7 +1407,7 @@
       ],
       "links": [
         {
-          "label": "Spark DDL – ALTER TABLE",
+          "label": "Spark DDL \u2013 ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -1440,6 +1440,30 @@
       "caveats": [
         "Fabric does not support Iceberg V3"
       ],
+      "links": []
+    },
+    "azure-synapse:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Azure Synapse Analytics uses its own catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "azure-synapse:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Azure Synapse does not support external REST catalogs.",
+      "caveats": [],
+      "links": []
+    },
+    "azure-fabric:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Azure Fabric uses its own OneLake catalog and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "azure-fabric:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Azure Fabric does not support external REST catalogs.",
+      "caveats": [],
       "links": []
     }
   }

--- a/src/data/platforms/azure.json
+++ b/src/data/platforms/azure.json
@@ -325,7 +325,7 @@
       "notes": "Read support available only via Spark pools with manually installed iceberg-spark-runtime JAR; serverless SQL pool does NOT support Iceberg (only Parquet, Delta Lake, CSV); dedicated SQL pool has no Iceberg support",
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation on Spark pools",
-        "Serverless SQL pool does NOT support Iceberg \u2014 only Parquet, Delta Lake, and delimited text formats",
+        "Serverless SQL pool does NOT support Iceberg — only Parquet, Delta Lake, and delimited text formats",
         "Dedicated SQL pool has no Iceberg support",
         "Microsoft recommends migrating Synapse Spark workloads to Microsoft Fabric"
       ],
@@ -411,7 +411,7 @@
       "notes": "Standard Spark Iceberg catalogs (Hive, Hadoop, REST, JDBC) can be configured manually via Spark pool settings; no native Synapse catalog integration for Iceberg",
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation and Spark configuration",
-        "No native Synapse catalog integration for Iceberg \u2014 all catalog configuration is manual",
+        "No native Synapse catalog integration for Iceberg — all catalog configuration is manual",
         "Catalog type depends on user-supplied Spark configuration"
       ],
       "links": [
@@ -436,7 +436,7 @@
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation and Spark configuration",
         "Requires configuring spark.sql.catalog with org.apache.iceberg.spark.SparkCatalog",
-        "No native Synapse integration \u2014 standard OSS Spark Iceberg configuration"
+        "No native Synapse integration — standard OSS Spark Iceberg configuration"
       ],
       "links": [
         {
@@ -471,7 +471,7 @@
       "notes": "Iceberg REST Catalog can be configured via Spark pool settings using the standard Spark Iceberg RESTCatalog implementation",
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation and Spark configuration",
-        "No native Synapse REST catalog endpoint \u2014 must point to an external REST catalog server",
+        "No native Synapse REST catalog endpoint — must point to an external REST catalog server",
         "Standard OSS Spark Iceberg configuration applies"
       ],
       "links": [
@@ -544,7 +544,7 @@
       "caveats": [
         "Iceberg is not pre-installed; requires manual JAR package installation and Spark configuration",
         "Uses ADLS Gen2 (abfss://) as the underlying storage; standard Hadoop catalog with ADLS connector",
-        "No native Synapse integration \u2014 standard OSS Spark Iceberg configuration"
+        "No native Synapse integration — standard OSS Spark Iceberg configuration"
       ],
       "links": [
         {
@@ -708,7 +708,7 @@
       "level": "unknown",
       "notes": "OneLake virtualizes Iceberg tables as Delta Lake using Apache XTable, which converts positional delete files during Iceberg-to-Delta conversion",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Position deletes are translated during metadata virtualization; not a native Iceberg engine"
       ],
       "links": [
@@ -739,7 +739,7 @@
       "level": "unknown",
       "notes": "Equality delete support depends on the Apache XTable virtualization layer that converts Iceberg metadata to Delta Lake format",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Equality delete handling depends on XTable conversion fidelity"
       ],
       "links": [
@@ -761,7 +761,7 @@
       "level": "unknown",
       "notes": "When reading external Iceberg tables via shortcuts, merge-on-read is handled by the XTable virtualization layer converting to Delta Lake",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Fabric uses Delta Lake merge strategies internally, not Iceberg MoR"
       ],
       "links": [
@@ -783,7 +783,7 @@
       "level": "unknown",
       "notes": "Fabric uses Delta Lake copy-on-write internally; when Delta tables are virtualized as Iceberg, the underlying CoW behavior is preserved",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "CoW is the underlying Delta Lake behavior, not native Iceberg CoW"
       ],
       "links": [
@@ -805,7 +805,7 @@
       "level": "unknown",
       "notes": "Schema evolution works on the Delta Lake side; for Iceberg shortcuts, metadata changes may not be immediately reflected until a data change occurs",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Iceberg metadata changes (add/drop/rename columns) may require a data change to trigger re-conversion"
       ],
       "links": [
@@ -855,7 +855,7 @@
       "level": "unknown",
       "notes": "Iceberg hidden partitioning is preserved when reading via OneLake shortcuts; Fabric creates Delta partitioned tables natively, which are virtualized as Iceberg",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Partitioning is translated between formats during virtualization"
       ],
       "links": [
@@ -877,7 +877,7 @@
       "level": "unknown",
       "notes": "Partition evolution support depends on the metadata virtualization layer; may have limitations compared to native Iceberg partition evolution",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Partition evolution may not fully round-trip through Delta-Iceberg virtualization"
       ],
       "links": [
@@ -913,7 +913,7 @@
       "level": "unknown",
       "notes": "Time travel is available on Delta Lake tables within Fabric; for Iceberg shortcuts virtualized as Delta, time travel operates on the Delta log, not Iceberg snapshots",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Time travel operates on virtualized Delta log, not native Iceberg snapshot history"
       ],
       "links": [
@@ -935,7 +935,7 @@
       "level": "unknown",
       "notes": "Fabric provides automatic optimization (compaction, V-Order) for Delta Lake tables; for Iceberg shortcuts, maintenance must be performed by the source Iceberg writer",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Auto-optimization applies to Delta tables only; Iceberg shortcuts require external maintenance"
       ],
       "links": [
@@ -1007,7 +1007,7 @@
       "level": "unknown",
       "notes": "Fabric writes Delta Lake tables natively, which are auto-virtualized as Iceberg for external readers. External tools (e.g., Snowflake) can write Iceberg tables directly to OneLake. Fabric itself does not write native Iceberg format.",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Fabric engines write Delta Lake, not native Iceberg; external Iceberg writers (Snowflake) can write directly to OneLake"
       ],
       "links": [
@@ -1033,7 +1033,7 @@
       "level": "unknown",
       "notes": "DML operations (MERGE, UPDATE, DELETE) operate on Delta Lake tables within Fabric; changes are reflected in the virtualized Iceberg view. No native Iceberg DML from Fabric engines.",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "DML is Delta Lake-based; Iceberg view is read-only from Fabric perspective"
       ],
       "links": [
@@ -1202,7 +1202,7 @@
       "level": "unknown",
       "notes": "Fabric creates Delta Lake tables (via Spark notebooks, pipelines, etc.) that are automatically virtualized as Iceberg for external readers. External writers (e.g., Snowflake) can create Iceberg tables directly in OneLake.",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Native Iceberg table creation only via external writers (e.g., Snowflake); Fabric creates Delta tables virtualized as Iceberg"
       ],
       "links": [
@@ -1359,7 +1359,7 @@
       "level": "unknown",
       "notes": "When Fabric virtualizes Delta Lake tables as Iceberg via Apache XTable, column statistics are translated from Delta Lake statistics to Iceberg manifest statistics. For external Iceberg tables read via OneLake shortcuts, existing statistics are preserved.",
       "caveats": [
-        "Iceberg support is via metadata virtualization (Apache XTable) \u2014 Fabric natively uses Delta Lake, not Iceberg",
+        "Iceberg support is via metadata virtualization (Apache XTable) — Fabric natively uses Delta Lake, not Iceberg",
         "Statistics quality depends on the Delta-to-Iceberg virtualization fidelity"
       ],
       "links": [
@@ -1381,7 +1381,7 @@
       "level": "unknown",
       "notes": "Fabric does not support Iceberg bloom filters. Delta Lake tables virtualized as Iceberg do not include bloom filter metadata in the Iceberg representation.",
       "caveats": [
-        "Iceberg support is via metadata virtualization \u2014 Fabric natively uses Delta Lake, not Iceberg"
+        "Iceberg support is via metadata virtualization — Fabric natively uses Delta Lake, not Iceberg"
       ],
       "links": [
         {
@@ -1407,7 +1407,7 @@
       ],
       "links": [
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -1455,10 +1455,22 @@
       "links": []
     },
     "azure-fabric:snowflake-horizon-catalog:v2": {
-      "level": "none",
-      "notes": "Azure Fabric uses its own OneLake catalog and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
-      "caveats": [],
-      "links": []
+      "level": "partial",
+      "notes": "Microsoft OneLake and Snowflake interoperability is generally available (Feb 2026). Fabric can bidirectionally read Iceberg data managed by Snowflake via Horizon Catalog, and Snowflake-managed Iceberg tables can be natively stored in OneLake. Write access from Fabric engines to Snowflake-managed Iceberg tables via Horizon Catalog is not supported.",
+      "caveats": [
+        "Read interop is GA; write from Fabric to Snowflake-managed Iceberg not supported via Horizon Catalog",
+        "Requires OneLake Snowflake item configuration"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
+        },
+        {
+          "label": "Microsoft OneLake and Snowflake interoperability (GA)",
+          "url": "https://blog.fabric.microsoft.com/en-GB/blog/microsoft-onelake-and-snowflake-interoperability-is-now-generally-available/"
+        }
+      ]
     },
     "azure-fabric:snowflake-horizon-catalog:v3": {
       "level": "none",

--- a/src/data/platforms/databricks.json
+++ b/src/data/platforms/databricks.json
@@ -914,24 +914,24 @@
         }
       ]
     },
-    "databricks:snowflake-open-catalog:v2": {
+    "databricks:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Databricks can connect to Snowflake Open Catalog via ICEBERG_REST catalog integration. Unity Catalog is the primary catalog; cross-catalog queries have limitations.",
+      "notes": "Databricks can connect to Snowflake Horizon Catalog via ICEBERG_REST catalog integration for read access. Databricks does not support writes to externally managed Iceberg tables \u2014 this is a Databricks engine limitation, not a Horizon Catalog limitation. Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog.",
       "caveats": [
-        "Unity Catalog is the primary catalog; Open Catalog is an external REST catalog",
-        "Cross-catalog write operations may have limitations",
-        "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)"
+        "Read-only \u2014 Databricks does not support writes to externally managed Iceberg tables (Databricks engine limitation)",
+        "Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog",
+        "Managed Iceberg tables in Databricks are in Public Preview (requires DBR 16.4 LTS+)"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "databricks:snowflake-open-catalog:v3": {
+    "databricks:snowflake-horizon-catalog:v3": {
       "level": "unknown",
-      "notes": "V3 support for Databricks connecting to Snowflake Open Catalog not yet documented.",
+      "notes": "V3 support for Databricks connecting to Snowflake Horizon Catalog not yet documented.",
       "caveats": [
         "V3 cross-catalog support not yet documented"
       ],

--- a/src/data/platforms/databricks.json
+++ b/src/data/platforms/databricks.json
@@ -356,7 +356,7 @@
     },
     "databricks:read-support:v2": {
       "level": "full",
-      "notes": "Full read support for native managed Iceberg v2 tables via Unity Catalog (Public Preview, DBR 16.4 LTS+). Also supports read-only access to foreign Iceberg tables via Lakehouse Federation. Note: UniForm is a separate Delta Lake feature that exposes Delta tables as Iceberg \u2014 it is not native Iceberg.",
+      "notes": "Full read support for native managed Iceberg v2 tables via Unity Catalog (Public Preview, DBR 16.4 LTS+). Also supports read-only access to foreign Iceberg tables via Lakehouse Federation. Note: UniForm is a separate Delta Lake feature that exposes Delta tables as Iceberg — it is not native Iceberg.",
       "caveats": [
         "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)",
         "Some data types not supported: UUID, Fixed(L), TIME, nested STRUCT with required fields",
@@ -392,7 +392,7 @@
       "notes": "INSERT INTO fully supported for native managed Iceberg tables in Unity Catalog. External engines can also write via the Iceberg REST Catalog API. Note: UniForm tables are read-only for Iceberg clients.",
       "caveats": [
         "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)",
-        "UniForm (Delta + Iceberg reads) tables are read-only for Iceberg clients \u2014 this is not native Iceberg"
+        "UniForm (Delta + Iceberg reads) tables are read-only for Iceberg clients — this is not native Iceberg"
       ],
       "links": [
         {
@@ -671,7 +671,7 @@
     },
     "databricks:table-creation:v2": {
       "level": "full",
-      "notes": "Supports CREATE TABLE ... USING iceberg for native managed Iceberg tables in Unity Catalog. External engines can also create tables via the REST Catalog API. Note: UniForm (TBLPROPERTIES delta.universalFormat.enabledFormats = 'iceberg') creates Delta tables with Iceberg reads \u2014 not native Iceberg.",
+      "notes": "Supports CREATE TABLE ... USING iceberg for native managed Iceberg tables in Unity Catalog. External engines can also create tables via the REST Catalog API. Note: UniForm (TBLPROPERTIES delta.universalFormat.enabledFormats = 'iceberg') creates Delta tables with Iceberg reads — not native Iceberg.",
       "caveats": [
         "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)",
         "Predictive optimization must be enabled for managed Iceberg table creation",
@@ -826,7 +826,7 @@
       "level": "full",
       "notes": "Row lineage is required and automatically enabled on all native Iceberg v3 tables. Tracks incremental changes with unique row IDs and last-modified sequence numbers. Requires DBR 17.3+ (Beta).",
       "caveats": [
-        "Row lineage is required for all v3 tables \u2014 cannot be disabled",
+        "Row lineage is required for all v3 tables — cannot be disabled",
         "Iceberg v3 features are in Beta (requires DBR 17.3+)"
       ],
       "links": [
@@ -916,9 +916,9 @@
     },
     "databricks:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Databricks can connect to Snowflake Horizon Catalog via ICEBERG_REST catalog integration for read access. Databricks does not support writes to externally managed Iceberg tables \u2014 this is a Databricks engine limitation, not a Horizon Catalog limitation. Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog.",
+      "notes": "Databricks can connect to Snowflake Horizon Catalog via ICEBERG_REST catalog integration for read access. Databricks does not support writes to externally managed Iceberg tables — this is a Databricks engine limitation, not a Horizon Catalog limitation. Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog.",
       "caveats": [
-        "Read-only \u2014 Databricks does not support writes to externally managed Iceberg tables (Databricks engine limitation)",
+        "Read-only — Databricks does not support writes to externally managed Iceberg tables (Databricks engine limitation)",
         "Unity Catalog is the primary catalog; Horizon Catalog is an external REST catalog",
         "Managed Iceberg tables in Databricks are in Public Preview (requires DBR 16.4 LTS+)"
       ],
@@ -930,12 +930,19 @@
       ]
     },
     "databricks:snowflake-horizon-catalog:v3": {
-      "level": "unknown",
-      "notes": "V3 support for Databricks connecting to Snowflake Horizon Catalog not yet documented.",
+      "level": "partial",
+      "notes": "Databricks can read Iceberg V3 tables via the Horizon Catalog REST API; however, Databricks does not support the full V3 spec. Tables using V3-only features such as nanosecond timestamps or deletion vectors may fail to read. Write support is not available — this is a Databricks engine limitation, not a Horizon Catalog limitation.",
       "caveats": [
-        "V3 cross-catalog support not yet documented"
+        "Read-only — Databricks does not support writes to externally managed Iceberg tables (Databricks engine limitation)",
+        "Tables using V3-only features (nanosecond timestamps, deletion vectors) may fail to read",
+        "Databricks does not support the full Iceberg V3 spec"
       ],
-      "links": []
+      "links": [
+        {
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
+        }
+      ]
     }
   }
 }

--- a/src/data/platforms/databricks.json
+++ b/src/data/platforms/databricks.json
@@ -356,7 +356,7 @@
     },
     "databricks:read-support:v2": {
       "level": "full",
-      "notes": "Full read support for native managed Iceberg v2 tables via Unity Catalog (Public Preview, DBR 16.4 LTS+). Also supports read-only access to foreign Iceberg tables via Lakehouse Federation. Note: UniForm is a separate Delta Lake feature that exposes Delta tables as Iceberg — it is not native Iceberg.",
+      "notes": "Full read support for native managed Iceberg v2 tables via Unity Catalog (Public Preview, DBR 16.4 LTS+). Also supports read-only access to foreign Iceberg tables via Lakehouse Federation. Note: UniForm is a separate Delta Lake feature that exposes Delta tables as Iceberg \u2014 it is not native Iceberg.",
       "caveats": [
         "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)",
         "Some data types not supported: UUID, Fixed(L), TIME, nested STRUCT with required fields",
@@ -392,7 +392,7 @@
       "notes": "INSERT INTO fully supported for native managed Iceberg tables in Unity Catalog. External engines can also write via the Iceberg REST Catalog API. Note: UniForm tables are read-only for Iceberg clients.",
       "caveats": [
         "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)",
-        "UniForm (Delta + Iceberg reads) tables are read-only for Iceberg clients — this is not native Iceberg"
+        "UniForm (Delta + Iceberg reads) tables are read-only for Iceberg clients \u2014 this is not native Iceberg"
       ],
       "links": [
         {
@@ -671,7 +671,7 @@
     },
     "databricks:table-creation:v2": {
       "level": "full",
-      "notes": "Supports CREATE TABLE ... USING iceberg for native managed Iceberg tables in Unity Catalog. External engines can also create tables via the REST Catalog API. Note: UniForm (TBLPROPERTIES delta.universalFormat.enabledFormats = 'iceberg') creates Delta tables with Iceberg reads — not native Iceberg.",
+      "notes": "Supports CREATE TABLE ... USING iceberg for native managed Iceberg tables in Unity Catalog. External engines can also create tables via the REST Catalog API. Note: UniForm (TBLPROPERTIES delta.universalFormat.enabledFormats = 'iceberg') creates Delta tables with Iceberg reads \u2014 not native Iceberg.",
       "caveats": [
         "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)",
         "Predictive optimization must be enabled for managed Iceberg table creation",
@@ -826,7 +826,7 @@
       "level": "full",
       "notes": "Row lineage is required and automatically enabled on all native Iceberg v3 tables. Tracks incremental changes with unique row IDs and last-modified sequence numbers. Requires DBR 17.3+ (Beta).",
       "caveats": [
-        "Row lineage is required for all v3 tables — cannot be disabled",
+        "Row lineage is required for all v3 tables \u2014 cannot be disabled",
         "Iceberg v3 features are in Beta (requires DBR 17.3+)"
       ],
       "links": [
@@ -913,6 +913,29 @@
           "url": "https://docs.databricks.com/aws/en/iceberg/iceberg-v3"
         }
       ]
+    },
+    "databricks:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "Databricks can connect to Snowflake Open Catalog via ICEBERG_REST catalog integration. Unity Catalog is the primary catalog; cross-catalog queries have limitations.",
+      "caveats": [
+        "Unity Catalog is the primary catalog; Open Catalog is an external REST catalog",
+        "Cross-catalog write operations may have limitations",
+        "Managed Iceberg tables are in Public Preview (requires DBR 16.4 LTS+)"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "databricks:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "V3 support for Databricks connecting to Snowflake Open Catalog not yet documented.",
+      "caveats": [
+        "V3 cross-catalog support not yet documented"
+      ],
+      "links": []
     }
   }
 }

--- a/src/data/platforms/firehose.json
+++ b/src/data/platforms/firehose.json
@@ -383,6 +383,18 @@
       "notes": "Firehose does not support Iceberg V3",
       "caveats": [],
       "links": []
+    },
+    "aws-firehose:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "Firehose is a write-only delivery service that uses AWS Glue Catalog exclusively and does not support REST catalog connections.",
+      "caveats": [],
+      "links": []
+    },
+    "aws-firehose:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "Firehose does not support Iceberg V3.",
+      "caveats": [],
+      "links": []
     }
   }
 }

--- a/src/data/platforms/firehose.json
+++ b/src/data/platforms/firehose.json
@@ -384,13 +384,13 @@
       "caveats": [],
       "links": []
     },
-    "aws-firehose:snowflake-open-catalog:v2": {
+    "aws-firehose:snowflake-horizon-catalog:v2": {
       "level": "none",
       "notes": "Firehose is a write-only delivery service that uses AWS Glue Catalog exclusively and does not support REST catalog connections.",
       "caveats": [],
       "links": []
     },
-    "aws-firehose:snowflake-open-catalog:v3": {
+    "aws-firehose:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "Firehose does not support Iceberg V3.",
       "caveats": [],

--- a/src/data/platforms/gcp.json
+++ b/src/data/platforms/gcp.json
@@ -1188,7 +1188,7 @@
       "caveats": [],
       "links": [
         {
-          "label": "Spark DDL – ALTER TABLE",
+          "label": "Spark DDL \u2013 ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -1199,8 +1199,44 @@
       "caveats": [],
       "links": [
         {
-          "label": "Spark DDL – ALTER TABLE",
+          "label": "Spark DDL \u2013 ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
+        }
+      ]
+    },
+    "google-bigquery:snowflake-open-catalog:v2": {
+      "level": "none",
+      "notes": "BigQuery uses its own managed metastore and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "caveats": [],
+      "links": []
+    },
+    "google-bigquery:snowflake-open-catalog:v3": {
+      "level": "none",
+      "notes": "BigQuery does not support external REST catalogs.",
+      "caveats": [],
+      "links": []
+    },
+    "google-dataproc:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Dataproc runs Spark and supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "google-dataproc:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support via Dataproc Spark requires iceberg-spark-runtime 1.7.0+.",
+      "caveats": [
+        "Requires iceberg-spark-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
         }
       ]
     }

--- a/src/data/platforms/gcp.json
+++ b/src/data/platforms/gcp.json
@@ -1188,7 +1188,7 @@
       "caveats": [],
       "links": [
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -1199,7 +1199,7 @@
       "caveats": [],
       "links": [
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -1218,7 +1218,7 @@
     },
     "google-dataproc:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Dataproc runs Spark and supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
+      "notes": "Dataproc runs Spark and supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest pointing to the Horizon Catalog endpoint.",
       "caveats": [],
       "links": [
         {

--- a/src/data/platforms/gcp.json
+++ b/src/data/platforms/gcp.json
@@ -1204,30 +1204,30 @@
         }
       ]
     },
-    "google-bigquery:snowflake-open-catalog:v2": {
+    "google-bigquery:snowflake-horizon-catalog:v2": {
       "level": "none",
-      "notes": "BigQuery uses its own managed metastore and does not support connecting to external REST catalogs including Snowflake Open Catalog.",
+      "notes": "BigQuery uses its own managed metastore and does not support connecting to external REST catalogs including Snowflake Horizon Catalog.",
       "caveats": [],
       "links": []
     },
-    "google-bigquery:snowflake-open-catalog:v3": {
+    "google-bigquery:snowflake-horizon-catalog:v3": {
       "level": "none",
       "notes": "BigQuery does not support external REST catalogs.",
       "caveats": [],
       "links": []
     },
-    "google-dataproc:snowflake-open-catalog:v2": {
+    "google-dataproc:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "Dataproc runs Spark and supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest pointing to the Open Catalog endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "google-dataproc:snowflake-open-catalog:v3": {
+    "google-dataproc:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support via Dataproc Spark requires iceberg-spark-runtime 1.7.0+.",
       "caveats": [
@@ -1235,8 +1235,8 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     }

--- a/src/data/platforms/kafka-connect.json
+++ b/src/data/platforms/kafka-connect.json
@@ -435,20 +435,20 @@
       ],
       "links": []
     },
-    "kafka-connect:snowflake-open-catalog:v2": {
+    "kafka-connect:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "Kafka Connect Iceberg sink supports REST catalog type natively. Snowflake Open Catalog implements the same REST Catalog spec as Apache Polaris.",
+      "notes": "Kafka Connect Iceberg sink supports REST catalog type natively. Snowflake Horizon Catalog implements the same REST Catalog spec as Apache Polaris.",
       "caveats": [
         "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "kafka-connect:snowflake-open-catalog:v3": {
+    "kafka-connect:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "REST catalog support unchanged for V3. V3 feature support depends on Iceberg library version bundled.",
       "caveats": [
@@ -456,8 +456,8 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     }

--- a/src/data/platforms/kafka-connect.json
+++ b/src/data/platforms/kafka-connect.json
@@ -439,7 +439,7 @@
       "level": "partial",
       "notes": "Kafka Connect Iceberg sink supports REST catalog type natively. Snowflake Horizon Catalog implements the same REST Catalog spec as Apache Polaris.",
       "caveats": [
-        "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
+        "Not explicitly documented for Horizon Catalog specifically; works through REST Catalog compatibility"
       ],
       "links": [
         {
@@ -452,7 +452,7 @@
       "level": "partial",
       "notes": "REST catalog support unchanged for V3. V3 feature support depends on Iceberg library version bundled.",
       "caveats": [
-        "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
+        "Not explicitly documented for Horizon Catalog specifically; works through REST Catalog compatibility"
       ],
       "links": [
         {

--- a/src/data/platforms/kafka-connect.json
+++ b/src/data/platforms/kafka-connect.json
@@ -13,32 +13,44 @@
     "kafka-connect:position-deletes:v2": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; does not write position delete files",
-      "caveats": ["OSS connector only supports appends"]
+      "caveats": [
+        "OSS connector only supports appends"
+      ]
     },
     "kafka-connect:position-deletes:v3": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; does not write position delete files",
-      "caveats": ["OSS connector only supports appends"]
+      "caveats": [
+        "OSS connector only supports appends"
+      ]
     },
     "kafka-connect:equality-deletes:v2": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; does not write equality delete files",
-      "caveats": ["OSS connector only supports appends; equality deletes require Tabular/Confluent commercial connector"]
+      "caveats": [
+        "OSS connector only supports appends; equality deletes require Tabular/Confluent commercial connector"
+      ]
     },
     "kafka-connect:equality-deletes:v3": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; does not write equality delete files",
-      "caveats": ["OSS connector only supports appends; equality deletes require Tabular/Confluent commercial connector"]
+      "caveats": [
+        "OSS connector only supports appends; equality deletes require Tabular/Confluent commercial connector"
+      ]
     },
     "kafka-connect:merge-on-read:v2": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; merge-on-read not applicable",
-      "caveats": ["OSS connector only supports appends"]
+      "caveats": [
+        "OSS connector only supports appends"
+      ]
     },
     "kafka-connect:merge-on-read:v3": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; merge-on-read not applicable",
-      "caveats": ["OSS connector only supports appends"]
+      "caveats": [
+        "OSS connector only supports appends"
+      ]
     },
     "kafka-connect:copy-on-write:v2": {
       "level": "none",
@@ -53,12 +65,16 @@
     "kafka-connect:schema-evolution:v2": {
       "level": "partial",
       "notes": "Schema evolution adds missing record fields to the table schema when iceberg.tables.evolve-schema-enabled is true",
-      "caveats": ["Only supports adding new columns; does not support column renaming, reordering, or type promotion"]
+      "caveats": [
+        "Only supports adding new columns; does not support column renaming, reordering, or type promotion"
+      ]
     },
     "kafka-connect:schema-evolution:v3": {
       "level": "partial",
       "notes": "Schema evolution adds missing record fields to the table schema when iceberg.tables.evolve-schema-enabled is true",
-      "caveats": ["Only supports adding new columns; does not support column renaming, reordering, or type promotion"]
+      "caveats": [
+        "Only supports adding new columns; does not support column renaming, reordering, or type promotion"
+      ]
     },
     "kafka-connect:column-default-values:v2": {
       "level": "none",
@@ -83,12 +99,16 @@
     "kafka-connect:hidden-partitioning:v2": {
       "level": "partial",
       "notes": "Partition transforms can be specified via iceberg.tables.default-partition-by or per-table partition-by when auto-creating tables",
-      "caveats": ["Only applies during auto table creation; does not modify partitioning of existing tables"]
+      "caveats": [
+        "Only applies during auto table creation; does not modify partitioning of existing tables"
+      ]
     },
     "kafka-connect:hidden-partitioning:v3": {
       "level": "partial",
       "notes": "Partition transforms can be specified via iceberg.tables.default-partition-by or per-table partition-by when auto-creating tables",
-      "caveats": ["Only applies during auto table creation; does not modify partitioning of existing tables"]
+      "caveats": [
+        "Only applies during auto table creation; does not modify partitioning of existing tables"
+      ]
     },
     "kafka-connect:partition-evolution:v2": {
       "level": "none",
@@ -133,12 +153,16 @@
     "kafka-connect:branching-tagging:v2": {
       "level": "partial",
       "notes": "Supports writing to a specific branch via iceberg.tables.default-commit-branch or per-table commit-branch configuration",
-      "caveats": ["Write-to-branch only; cannot create, delete, or manage branches/tags"]
+      "caveats": [
+        "Write-to-branch only; cannot create, delete, or manage branches/tags"
+      ]
     },
     "kafka-connect:branching-tagging:v3": {
       "level": "partial",
       "notes": "Supports writing to a specific branch via iceberg.tables.default-commit-branch or per-table commit-branch configuration",
-      "caveats": ["Write-to-branch only; cannot create, delete, or manage branches/tags"]
+      "caveats": [
+        "Write-to-branch only; cannot create, delete, or manage branches/tags"
+      ]
     },
     "kafka-connect:read-support:v2": {
       "level": "none",
@@ -163,12 +187,16 @@
     "kafka-connect:write-merge-update-delete:v2": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; does not support MERGE, UPDATE, or DELETE operations",
-      "caveats": ["OSS connector only supports appends; upsert/CDC modes require Tabular/Confluent commercial connector"]
+      "caveats": [
+        "OSS connector only supports appends; upsert/CDC modes require Tabular/Confluent commercial connector"
+      ]
     },
     "kafka-connect:write-merge-update-delete:v3": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; does not support MERGE, UPDATE, or DELETE operations",
-      "caveats": ["OSS connector only supports appends; upsert/CDC modes require Tabular/Confluent commercial connector"]
+      "caveats": [
+        "OSS connector only supports appends; upsert/CDC modes require Tabular/Confluent commercial connector"
+      ]
     },
     "kafka-connect:catalog-integration:v2": {
       "level": "full",
@@ -223,12 +251,16 @@
     "kafka-connect:polaris:v2": {
       "level": "partial",
       "notes": "Polaris can be used via REST Catalog protocol as Polaris implements the Iceberg REST Catalog spec",
-      "caveats": ["Not explicitly documented; works through REST Catalog compatibility"]
+      "caveats": [
+        "Not explicitly documented; works through REST Catalog compatibility"
+      ]
     },
     "kafka-connect:polaris:v3": {
       "level": "partial",
       "notes": "Polaris can be used via REST Catalog protocol as Polaris implements the Iceberg REST Catalog spec",
-      "caveats": ["Not explicitly documented; works through REST Catalog compatibility"]
+      "caveats": [
+        "Not explicitly documented; works through REST Catalog compatibility"
+      ]
     },
     "kafka-connect:unity-catalog:v2": {
       "level": "none",
@@ -253,22 +285,30 @@
     "kafka-connect:jdbc-catalog:v2": {
       "level": "partial",
       "notes": "JDBC Catalog supported via catalog-impl but JDBC drivers are not included in the default distribution",
-      "caveats": ["Requires adding JDBC driver dependency manually"]
+      "caveats": [
+        "Requires adding JDBC driver dependency manually"
+      ]
     },
     "kafka-connect:jdbc-catalog:v3": {
       "level": "partial",
       "notes": "JDBC Catalog supported via catalog-impl but JDBC drivers are not included in the default distribution",
-      "caveats": ["Requires adding JDBC driver dependency manually"]
+      "caveats": [
+        "Requires adding JDBC driver dependency manually"
+      ]
     },
     "kafka-connect:table-creation:v2": {
       "level": "partial",
       "notes": "Supports automatic table creation via iceberg.tables.auto-create-enabled with schema inferred from incoming records",
-      "caveats": ["Schema derived from incoming Kafka records; supports configuring partitioning and identity columns via connector properties"]
+      "caveats": [
+        "Schema derived from incoming Kafka records; supports configuring partitioning and identity columns via connector properties"
+      ]
     },
     "kafka-connect:table-creation:v3": {
       "level": "partial",
       "notes": "Supports automatic table creation via iceberg.tables.auto-create-enabled with schema inferred from incoming records",
-      "caveats": ["Schema derived from incoming Kafka records; supports configuring partitioning and identity columns via connector properties"]
+      "caveats": [
+        "Schema derived from incoming Kafka records; supports configuring partitioning and identity columns via connector properties"
+      ]
     },
     "kafka-connect:variant-type:v2": {
       "level": "none",
@@ -313,12 +353,16 @@
     "kafka-connect:cdc-support:v2": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; CDC/upsert modes are only available in the Tabular/Confluent commercial connector",
-      "caveats": ["OSS connector only supports appends; CDC requires Tabular/Confluent commercial connector"]
+      "caveats": [
+        "OSS connector only supports appends; CDC requires Tabular/Confluent commercial connector"
+      ]
     },
     "kafka-connect:cdc-support:v3": {
       "level": "none",
       "notes": "Apache Iceberg OSS Kafka Connect sink is append-only; CDC/upsert modes are only available in the Tabular/Confluent commercial connector",
-      "caveats": ["OSS connector only supports appends; CDC requires Tabular/Confluent commercial connector"]
+      "caveats": [
+        "OSS connector only supports appends; CDC requires Tabular/Confluent commercial connector"
+      ]
     },
     "kafka-connect:lineage:v2": {
       "level": "none",
@@ -333,19 +377,35 @@
     "kafka-connect:statistics:v2": {
       "level": "partial",
       "notes": "Kafka Connect Iceberg sink writes basic column statistics to manifest files via the standard Iceberg write path when appending data",
-      "caveats": ["Sink-only connector; limited statistics configuration"],
-      "links": [{"label": "Kafka Connect Iceberg", "url": "https://iceberg.apache.org/docs/latest/kafka-connect/"}]
+      "caveats": [
+        "Sink-only connector; limited statistics configuration"
+      ],
+      "links": [
+        {
+          "label": "Kafka Connect Iceberg",
+          "url": "https://iceberg.apache.org/docs/latest/kafka-connect/"
+        }
+      ]
     },
     "kafka-connect:statistics:v3": {
       "level": "partial",
       "notes": "Basic column statistics written via standard Iceberg write path for V3 tables",
-      "caveats": ["Limited statistics configuration compared to Spark"],
-      "links": [{"label": "Kafka Connect Iceberg", "url": "https://iceberg.apache.org/docs/latest/kafka-connect/"}]
+      "caveats": [
+        "Limited statistics configuration compared to Spark"
+      ],
+      "links": [
+        {
+          "label": "Kafka Connect Iceberg",
+          "url": "https://iceberg.apache.org/docs/latest/kafka-connect/"
+        }
+      ]
     },
     "kafka-connect:bloom-filters:v2": {
       "level": "none",
       "notes": "Kafka Connect Iceberg sink does not support configuring Parquet-level bloom filters or Puffin-based bloom filter statistics",
-      "caveats": ["Sink-only connector with limited write configuration options"],
+      "caveats": [
+        "Sink-only connector with limited write configuration options"
+      ],
       "links": []
     },
     "kafka-connect:bloom-filters:v3": {
@@ -357,14 +417,49 @@
     "kafka-connect:type-promotion:v2": {
       "level": "none",
       "notes": "The Iceberg Kafka Connect sink connector does not support type promotion. Schema evolution is limited to adding new columns",
-      "caveats": ["Kafka Connect sink only supports adding new columns for schema evolution"],
-      "links": [{"label": "Kafka Connect for Iceberg", "url": "https://iceberg.apache.org/docs/nightly/kafka-connect/"}]
+      "caveats": [
+        "Kafka Connect sink only supports adding new columns for schema evolution"
+      ],
+      "links": [
+        {
+          "label": "Kafka Connect for Iceberg",
+          "url": "https://iceberg.apache.org/docs/nightly/kafka-connect/"
+        }
+      ]
     },
     "kafka-connect:type-promotion:v3": {
       "level": "none",
       "notes": "The Iceberg Kafka Connect sink connector does not support type promotion for V3 tables",
-      "caveats": ["Kafka Connect sink only supports adding new columns for schema evolution"],
+      "caveats": [
+        "Kafka Connect sink only supports adding new columns for schema evolution"
+      ],
       "links": []
+    },
+    "kafka-connect:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "Kafka Connect Iceberg sink supports REST catalog type natively. Snowflake Open Catalog implements the same REST Catalog spec as Apache Polaris.",
+      "caveats": [
+        "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "kafka-connect:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "REST catalog support unchanged for V3. V3 feature support depends on Iceberg library version bundled.",
+      "caveats": [
+        "Not explicitly documented for Open Catalog specifically; works through REST Catalog compatibility"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
     }
   }
 }

--- a/src/data/platforms/oss.json
+++ b/src/data/platforms/oss.json
@@ -3906,18 +3906,18 @@
         }
       ]
     },
-    "spark:snowflake-open-catalog:v2": {
+    "spark:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "Spark Iceberg connector supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest and the Open Catalog endpoint URI.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "spark:snowflake-open-catalog:v3": {
+    "spark:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support depends on iceberg-spark-runtime version (1.7.0+ recommended). REST catalog connectivity unchanged.",
       "caveats": [
@@ -3925,23 +3925,23 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "flink:snowflake-open-catalog:v2": {
+    "flink:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "Flink Iceberg connector supports REST catalog. Configure with catalog-type=rest and the Open Catalog endpoint URI.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "flink:snowflake-open-catalog:v3": {
+    "flink:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "V3 support depends on iceberg-flink-runtime version (1.7.0+ recommended). REST catalog connectivity unchanged.",
       "caveats": [
@@ -3949,23 +3949,23 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "duckdb:snowflake-open-catalog:v2": {
+    "duckdb:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "DuckDB Iceberg extension supports REST catalog for reads and writes. Configure with ATTACH using the Open Catalog REST endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "duckdb:snowflake-open-catalog:v3": {
+    "duckdb:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "DuckDB V3 Iceberg table support is partial; REST catalog connectivity to Open Catalog is not yet explicitly documented for V3.",
       "caveats": [
@@ -3973,21 +3973,21 @@
       ],
       "links": []
     },
-    "clickhouse:snowflake-open-catalog:v2": {
+    "clickhouse:snowflake-horizon-catalog:v2": {
       "level": "partial",
-      "notes": "ClickHouse supports REST catalog via the IcebergCatalog table function. Connection to Snowflake Open Catalog follows the same REST catalog configuration.",
+      "notes": "ClickHouse supports REST catalog via the IcebergCatalog table function. Connection to Snowflake Horizon Catalog follows the same REST catalog configuration.",
       "caveats": [
         "REST catalog support available but with configuration complexity",
         "Feature set may be limited compared to native catalog integrations"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "clickhouse:snowflake-open-catalog:v3": {
+    "clickhouse:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "ClickHouse V3 Iceberg support is not yet documented; REST catalog connectivity pattern unchanged.",
       "caveats": [
@@ -3995,18 +3995,18 @@
       ],
       "links": []
     },
-    "daft:snowflake-open-catalog:v2": {
+    "daft:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "Daft supports REST catalog natively via PyIceberg integration. Configure with type=rest and the Open Catalog endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "daft:snowflake-open-catalog:v3": {
+    "daft:snowflake-horizon-catalog:v3": {
       "level": "unknown",
       "notes": "Daft V3 REST catalog support not yet documented.",
       "caveats": [
@@ -4014,18 +4014,18 @@
       ],
       "links": []
     },
-    "pyiceberg:snowflake-open-catalog:v2": {
+    "pyiceberg:snowflake-horizon-catalog:v2": {
       "level": "full",
       "notes": "PyIceberg has first-class REST catalog support. Configure with type=rest and the Open Catalog endpoint in pyiceberg config.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "pyiceberg:snowflake-open-catalog:v3": {
+    "pyiceberg:snowflake-horizon-catalog:v3": {
       "level": "partial",
       "notes": "PyIceberg REST catalog support is available; V3 feature support depends on PyIceberg version (0.8.0+ recommended).",
       "caveats": [
@@ -4033,8 +4033,8 @@
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     }

--- a/src/data/platforms/oss.json
+++ b/src/data/platforms/oss.json
@@ -825,7 +825,7 @@
     },
     "clickhouse:schema-evolution:v2": {
       "level": "partial",
-      "notes": "Reading schema-evolved Iceberg tables is supported via the icebergS3/icebergLocal table functions (recommended approach): add/remove columns, reorder, nullable promotion, and limited type casting (int\u2192long, float\u2192double, decimal widening). Cannot change nested structures or array/map element types.",
+      "notes": "Reading schema-evolved Iceberg tables is supported via the icebergS3/icebergLocal table functions (recommended approach): add/remove columns, reorder, nullable promotion, and limited type casting (int→long, float→double, decimal widening). Cannot change nested structures or array/map element types.",
       "caveats": [
         "Read-only via table functions; cannot perform schema changes",
         "No nested structure or array/map element type evolution",
@@ -1429,7 +1429,7 @@
     },
     "spark:schema-evolution:v2": {
       "level": "full",
-      "notes": "Full schema evolution via ALTER TABLE: add, drop, rename, reorder columns, widen types (int\u2192long, float\u2192double), and modify nullability",
+      "notes": "Full schema evolution via ALTER TABLE: add, drop, rename, reorder columns, widen types (int→long, float→double), and modify nullability",
       "caveats": [],
       "links": [
         {
@@ -1977,7 +1977,7 @@
     },
     "flink:schema-evolution:v2": {
       "level": "partial",
-      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column and partition changes are not supported via Flink DDL",
+      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties — column and partition changes are not supported via Flink DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column additions, renames, drops, and reordering not supported via Flink SQL"
       ],
@@ -1985,7 +1985,7 @@
     },
     "flink:schema-evolution:v3": {
       "level": "partial",
-      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties \u2014 column and partition changes are not supported via Flink DDL",
+      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties — column and partition changes are not supported via Flink DDL",
       "caveats": [
         "ALTER TABLE only supports changing table properties; column additions, renames, drops, and reordering not supported via Flink SQL"
       ],
@@ -2087,7 +2087,7 @@
     },
     "flink:table-maintenance:v2": {
       "level": "partial",
-      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests \u2014 use Spark for full maintenance",
+      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests — use Spark for full maintenance",
       "caveats": [
         "Only rewrite files action available; expire_snapshots, remove_orphan_files, rewrite_manifests not supported"
       ],
@@ -3784,7 +3784,7 @@
     },
     "clickhouse:type-promotion:v2": {
       "level": "partial",
-      "notes": "ClickHouse can read Iceberg tables that have undergone type promotion (int\u2192long, float\u2192double, decimal precision widening) via the icebergS3/icebergLocal table functions (recommended approach). Cannot perform type promotion itself \u2014 that must be done by another engine (e.g. Spark). Nested structure and array/map element type changes are not supported.",
+      "notes": "ClickHouse can read Iceberg tables that have undergone type promotion (int→long, float→double, decimal precision widening) via the icebergS3/icebergLocal table functions (recommended approach). Cannot perform type promotion itself — that must be done by another engine (e.g. Spark). Nested structure and array/map element type changes are not supported.",
       "caveats": [
         "Read-only via table functions; cannot perform type promotion",
         "No nested structure or array/map element type evolution",
@@ -3838,7 +3838,7 @@
       "caveats": [],
       "links": [
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         },
         {
@@ -3853,7 +3853,7 @@
       "caveats": [],
       "links": [
         {
-          "label": "Spark DDL \u2013 ALTER TABLE",
+          "label": "Spark DDL – ALTER TABLE",
           "url": "https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table"
         }
       ]
@@ -3886,7 +3886,7 @@
       "caveats": [],
       "links": [
         {
-          "label": "PyIceberg API \u2013 Schema evolution",
+          "label": "PyIceberg API – Schema evolution",
           "url": "https://py.iceberg.apache.org/api/"
         },
         {
@@ -3901,14 +3901,14 @@
       "caveats": [],
       "links": [
         {
-          "label": "PyIceberg API \u2013 Schema evolution",
+          "label": "PyIceberg API – Schema evolution",
           "url": "https://py.iceberg.apache.org/api/"
         }
       ]
     },
     "spark:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Spark Iceberg connector supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest and the Open Catalog endpoint URI.",
+      "notes": "Spark Iceberg connector supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest and the Horizon Catalog endpoint URI.",
       "caveats": [],
       "links": [
         {
@@ -3932,7 +3932,7 @@
     },
     "flink:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Flink Iceberg connector supports REST catalog. Configure with catalog-type=rest and the Open Catalog endpoint URI.",
+      "notes": "Flink Iceberg connector supports REST catalog. Configure with catalog-type=rest and the Horizon Catalog endpoint URI.",
       "caveats": [],
       "links": [
         {
@@ -3956,7 +3956,7 @@
     },
     "duckdb:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "DuckDB Iceberg extension supports REST catalog for reads and writes. Configure with ATTACH using the Open Catalog REST endpoint.",
+      "notes": "DuckDB Iceberg extension supports REST catalog for reads and writes. Configure with ATTACH using the Horizon Catalog REST endpoint.",
       "caveats": [],
       "links": [
         {
@@ -3967,7 +3967,7 @@
     },
     "duckdb:snowflake-horizon-catalog:v3": {
       "level": "unknown",
-      "notes": "DuckDB V3 Iceberg table support is partial; REST catalog connectivity to Open Catalog is not yet explicitly documented for V3.",
+      "notes": "DuckDB V3 Iceberg table support is partial; REST catalog connectivity to Horizon Catalog is not yet explicitly documented for V3.",
       "caveats": [
         "V3 catalog support via DuckDB not yet documented"
       ],
@@ -3997,7 +3997,7 @@
     },
     "daft:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Daft supports REST catalog natively via PyIceberg integration. Configure with type=rest and the Open Catalog endpoint.",
+      "notes": "Daft supports REST catalog natively via PyIceberg integration. Configure with type=rest and the Horizon Catalog endpoint.",
       "caveats": [],
       "links": [
         {
@@ -4016,7 +4016,7 @@
     },
     "pyiceberg:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "PyIceberg has first-class REST catalog support. Configure with type=rest and the Open Catalog endpoint in pyiceberg config.",
+      "notes": "PyIceberg has first-class REST catalog support. Configure with type=rest and the Horizon Catalog endpoint in pyiceberg config.",
       "caveats": [],
       "links": [
         {

--- a/src/data/platforms/oss.json
+++ b/src/data/platforms/oss.json
@@ -825,7 +825,7 @@
     },
     "clickhouse:schema-evolution:v2": {
       "level": "partial",
-      "notes": "Reading schema-evolved Iceberg tables is supported via the icebergS3/icebergLocal table functions (recommended approach): add/remove columns, reorder, nullable promotion, and limited type casting (int→long, float→double, decimal widening). Cannot change nested structures or array/map element types.",
+      "notes": "Reading schema-evolved Iceberg tables is supported via the icebergS3/icebergLocal table functions (recommended approach): add/remove columns, reorder, nullable promotion, and limited type casting (int\u2192long, float\u2192double, decimal widening). Cannot change nested structures or array/map element types.",
       "caveats": [
         "Read-only via table functions; cannot perform schema changes",
         "No nested structure or array/map element type evolution",
@@ -3784,7 +3784,7 @@
     },
     "clickhouse:type-promotion:v2": {
       "level": "partial",
-      "notes": "ClickHouse can read Iceberg tables that have undergone type promotion (int→long, float→double, decimal precision widening) via the icebergS3/icebergLocal table functions (recommended approach). Cannot perform type promotion itself — that must be done by another engine (e.g. Spark). Nested structure and array/map element type changes are not supported.",
+      "notes": "ClickHouse can read Iceberg tables that have undergone type promotion (int\u2192long, float\u2192double, decimal precision widening) via the icebergS3/icebergLocal table functions (recommended approach). Cannot perform type promotion itself \u2014 that must be done by another engine (e.g. Spark). Nested structure and array/map element type changes are not supported.",
       "caveats": [
         "Read-only via table functions; cannot perform type promotion",
         "No nested structure or array/map element type evolution",
@@ -3903,6 +3903,138 @@
         {
           "label": "PyIceberg API \u2013 Schema evolution",
           "url": "https://py.iceberg.apache.org/api/"
+        }
+      ]
+    },
+    "spark:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Spark Iceberg connector supports REST catalog natively. Configure with spark.sql.catalog.<name>.type=rest and the Open Catalog endpoint URI.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "spark:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support depends on iceberg-spark-runtime version (1.7.0+ recommended). REST catalog connectivity unchanged.",
+      "caveats": [
+        "Requires iceberg-spark-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "flink:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Flink Iceberg connector supports REST catalog. Configure with catalog-type=rest and the Open Catalog endpoint URI.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "flink:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "V3 support depends on iceberg-flink-runtime version (1.7.0+ recommended). REST catalog connectivity unchanged.",
+      "caveats": [
+        "Requires iceberg-flink-runtime 1.7.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "duckdb:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "DuckDB Iceberg extension supports REST catalog for reads and writes. Configure with ATTACH using the Open Catalog REST endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "duckdb:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "DuckDB V3 Iceberg table support is partial; REST catalog connectivity to Open Catalog is not yet explicitly documented for V3.",
+      "caveats": [
+        "V3 catalog support via DuckDB not yet documented"
+      ],
+      "links": []
+    },
+    "clickhouse:snowflake-open-catalog:v2": {
+      "level": "partial",
+      "notes": "ClickHouse supports REST catalog via the IcebergCatalog table function. Connection to Snowflake Open Catalog follows the same REST catalog configuration.",
+      "caveats": [
+        "REST catalog support available but with configuration complexity",
+        "Feature set may be limited compared to native catalog integrations"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "clickhouse:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "ClickHouse V3 Iceberg support is not yet documented; REST catalog connectivity pattern unchanged.",
+      "caveats": [
+        "V3 support not yet documented in ClickHouse"
+      ],
+      "links": []
+    },
+    "daft:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Daft supports REST catalog natively via PyIceberg integration. Configure with type=rest and the Open Catalog endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "daft:snowflake-open-catalog:v3": {
+      "level": "unknown",
+      "notes": "Daft V3 REST catalog support not yet documented.",
+      "caveats": [
+        "V3 support via Daft not yet documented"
+      ],
+      "links": []
+    },
+    "pyiceberg:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "PyIceberg has first-class REST catalog support. Configure with type=rest and the Open Catalog endpoint in pyiceberg config.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "pyiceberg:snowflake-open-catalog:v3": {
+      "level": "partial",
+      "notes": "PyIceberg REST catalog support is available; V3 feature support depends on PyIceberg version (0.8.0+ recommended).",
+      "caveats": [
+        "Requires PyIceberg 0.8.0+ for V3 table support"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
         }
       ]
     }

--- a/src/data/platforms/snowflake.json
+++ b/src/data/platforms/snowflake.json
@@ -160,7 +160,7 @@
       ],
       "links": [
         {
-          "label": "Manage Iceberg tables \u2013 Schema",
+          "label": "Manage Iceberg tables – Schema",
           "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-manage"
         },
         {
@@ -1102,7 +1102,7 @@
     },
     "snowflake:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Native integration \u2014 Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Horizon Catalog as the REST endpoint.",
+      "notes": "Native integration — Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Horizon Catalog as the REST endpoint.",
       "caveats": [],
       "links": [
         {

--- a/src/data/platforms/snowflake.json
+++ b/src/data/platforms/snowflake.json
@@ -160,7 +160,7 @@
       ],
       "links": [
         {
-          "label": "Manage Iceberg tables – Schema",
+          "label": "Manage Iceberg tables \u2013 Schema",
           "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-manage"
         },
         {
@@ -1097,6 +1097,30 @@
         {
           "label": "Release Notes",
           "url": "https://docs.snowflake.com/en/release-notes/2026/other/2026-03-04-iceberg-v3-support-preview"
+        }
+      ]
+    },
+    "snowflake:snowflake-open-catalog:v2": {
+      "level": "full",
+      "notes": "Native integration \u2014 Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Open Catalog as the REST endpoint.",
+      "caveats": [],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+        }
+      ]
+    },
+    "snowflake:snowflake-open-catalog:v3": {
+      "level": "full",
+      "notes": "Full support for Iceberg V3 tables via Snowflake Open Catalog. Public Preview as of March 2026.",
+      "caveats": [
+        "Public Preview as of March 2026"
+      ],
+      "links": [
+        {
+          "label": "Snowflake Open Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
         }
       ]
     }

--- a/src/data/platforms/snowflake.json
+++ b/src/data/platforms/snowflake.json
@@ -474,7 +474,7 @@
       "notes": "INSERT INTO supported for Snowflake-managed Iceberg tables. Externally managed tables can also support writes when using Snowflake as a REST catalog.",
       "caveats": [
         "Fully supported for Snowflake-managed Iceberg tables",
-        "Externally managed tables support writes via Snowflake Open Catalog (REST catalog)"
+        "Externally managed tables support writes via Snowflake Horizon Catalog (REST catalog)"
       ],
       "links": [
         {
@@ -541,9 +541,9 @@
     },
     "snowflake:catalog-integration:v2": {
       "level": "full",
-      "notes": "Snowflake supports multiple catalog integrations including Snowflake Open Catalog (Polaris), REST Catalog, and AWS Glue.",
+      "notes": "Snowflake supports multiple catalog integrations including Snowflake Horizon Catalog (Polaris), REST Catalog, and AWS Glue.",
       "caveats": [
-        "Supports Snowflake Open Catalog (Polaris), REST Catalog, and AWS Glue as external catalogs",
+        "Supports Snowflake Horizon Catalog (Polaris), REST Catalog, and AWS Glue as external catalogs",
         "Snowflake can also serve as its own Iceberg catalog for managed tables"
       ],
       "links": [
@@ -697,9 +697,9 @@
     },
     "snowflake:polaris:v2": {
       "level": "full",
-      "notes": "Snowflake Open Catalog is built on the open-source Polaris project, providing native Polaris catalog integration.",
+      "notes": "Snowflake Horizon Catalog is built on the open-source Polaris project, providing native Polaris catalog integration.",
       "caveats": [
-        "Snowflake Open Catalog is Snowflake's managed service built on Polaris",
+        "Snowflake Horizon Catalog is Snowflake's managed service built on Polaris",
         "Native integration with full read and write support"
       ],
       "links": [
@@ -715,7 +715,7 @@
     },
     "snowflake:polaris:v3": {
       "level": "full",
-      "notes": "Snowflake Open Catalog (Polaris) supported for Iceberg V3 tables. Public Preview (as of March 2026).",
+      "notes": "Snowflake Horizon Catalog (Polaris) supported for Iceberg V3 tables. Public Preview (as of March 2026).",
       "caveats": [
         "Public Preview (as of March 2026)"
       ],
@@ -1100,27 +1100,27 @@
         }
       ]
     },
-    "snowflake:snowflake-open-catalog:v2": {
+    "snowflake:snowflake-horizon-catalog:v2": {
       "level": "full",
-      "notes": "Native integration \u2014 Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Open Catalog as the REST endpoint.",
+      "notes": "Native integration \u2014 Snowflake is the provider. Connect via CREATE CATALOG INTEGRATION TYPE=ICEBERG_REST with Snowflake Horizon Catalog as the REST endpoint.",
       "caveats": [],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     },
-    "snowflake:snowflake-open-catalog:v3": {
+    "snowflake:snowflake-horizon-catalog:v3": {
       "level": "full",
-      "notes": "Full support for Iceberg V3 tables via Snowflake Open Catalog. Public Preview as of March 2026.",
+      "notes": "Full support for Iceberg V3 tables via Snowflake Horizon Catalog. Public Preview as of March 2026.",
       "caveats": [
         "Public Preview as of March 2026"
       ],
       "links": [
         {
-          "label": "Snowflake Open Catalog docs",
-          "url": "https://docs.snowflake.com/en/user-guide/open-catalog-overview"
+          "label": "Snowflake Horizon Catalog docs",
+          "url": "https://docs.snowflake.com/en/user-guide/tables-iceberg-access-using-external-query-engine-snowflake-horizon"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Adds \`snowflake-horizon-catalog\` as a first-class feature column in the \`catalog-support\` category, alongside the existing \`unity-catalog\` (Databricks) entry
- Snowflake Horizon Catalog exposes the Iceberg REST Catalog API (Horizon Iceberg REST Catalog API), enabling external engines to read and write Snowflake-managed Iceberg tables without syncing through a separate catalog account
- Support entries added across all 19 platforms for both V2 and V3, using conservative levels where documentation is incomplete (\`unknown\` rather than claiming unsupported or supported without evidence)

## Support level summary

| Platform | V2 | V3 |
|---|---|---|
| Snowflake | full | full |
| OSS Spark, Flink, PyIceberg | full | partial |
| DuckDB, Daft | full | unknown |
| Databricks | partial | partial |
| AWS EMR, Managed Flink | full | partial |
| AWS Athena | partial | none |
| AWS Glue, ClickHouse, Kafka Connect | partial | unknown/partial |
| AWS Redshift | unknown | none |
| Azure Fabric (OneLake) | partial | unknown |
| AWS Firehose, BigQuery, Synapse | none | none |

## Notes

- Databricks is marked \`partial\` for V2 and V3: Databricks does not support writes to externally managed Iceberg tables — this is a Databricks engine limitation, not a Horizon Catalog limitation; V3 tables are readable with caveats (nanosecond timestamps, deletion vectors may fail)
- AWS Athena V2 is \`partial\`: read-only access via AWS Glue Catalog Federation; V3 gap is an Athena engine limitation, not a Catalog Federation or Horizon Catalog limitation
- AWS Glue and EMR: write to externally-managed (federated) catalogs is not supported — Glue Spark only supports writes to Glue Data Catalog natively; this is a Glue engine limitation and does not apply to OSS Spark
- AWS Redshift V2 is \`unknown\`: may support reads via Glue Catalog Federation (same pattern as Athena) but unconfirmed; V3 is \`none\` (Redshift engine limitation)
- Azure Fabric (OneLake) V2 is \`partial\`: Microsoft OneLake ↔ Snowflake interoperability is GA (Feb 2026); bidirectional read supported; write from Fabric to Snowflake-managed Iceberg not supported via Horizon Catalog
- V3 levels default to \`unknown\` for most non-Snowflake platforms pending further testing against the Public Preview release (March 2026)
- All entries link to the Horizon Catalog docs
- Happy to update any levels if you have better data — kept conservative intentionally

## Reviewers and acknowledgments

AWS platform entries (Athena, EMR, Glue, Redshift) were validated and corrected by **Dan Hunt** (AWS Partner Sales Engineer, Snowflake — dan.hunt@snowflake.com). Naming and product framing reviewed by **Ashwin Kamath** (Staff Product Manager, Snowflake — ashwin.kamath@snowflake.com).

## Test plan

- [ ] CI lint + test + build passes
- [ ] \`snowflake-horizon-catalog\` appears in the matrix UI under \`catalog-support\`
- [ ] Support levels render correctly for Snowflake (full), Databricks (partial), Athena (partial), Firehose (none)
- [ ] No existing entries were modified (additions only)