### PR TITLE
Update PyIceberg V3 lineage and column default values to partial

### DIFF
--- a/src/data/platforms/oss/pyiceberg/pyiceberg.json
+++ b/src/data/platforms/oss/pyiceberg/pyiceberg.json
@@ -100,10 +100,20 @@
       "caveats": []
     },
     "pyiceberg:column-default-values:v3": {
-      "level": "none",
-      "notes": "PyIceberg does not yet support column default values",
+      "level": "partial",
+      "notes": "PyIceberg parses and preserves initial-default and write-default on schema fields, so tables with column defaults can be read and their metadata round-trips correctly. Writing data that applies defaults is pending V3 write support.",
       "caveats": [
-        "Not yet implemented"
+        "Read/metadata support only; defaults are not applied when writing data"
+      ],
+      "links": [
+        {
+          "label": "Default value read support (apache/iceberg-python#1644)",
+          "url": "https://github.com/apache/iceberg-python/pull/1644"
+        },
+        {
+          "label": "Write default support (apache/iceberg-python#1770)",
+          "url": "https://github.com/apache/iceberg-python/pull/1770"
+        }
       ]
     },
     "pyiceberg:table-creation:v2": {
@@ -404,10 +414,16 @@
       "caveats": []
     },
     "pyiceberg:lineage:v3": {
-      "level": "none",
-      "notes": "PyIceberg does not support lineage tracking",
+      "level": "partial",
+      "notes": "PyIceberg reads V3 row lineage metadata: next-row-id on table metadata and first-row-id on snapshots and manifests are parsed and exposed. Assigning row IDs on write is pending V3 write support.",
       "caveats": [
-        "Not yet implemented"
+        "Metadata read support only; PyIceberg cannot yet write V3 tables, so row IDs are not assigned on commit"
+      ],
+      "links": [
+        {
+          "label": "Row-level lineage issue (apache/iceberg-python#1821)",
+          "url": "https://github.com/apache/iceberg-python/issues/1821"
+        }
       ]
     },
     "pyiceberg:statistics:v2": {

--- a/tests/pyiceberg_feature_tests.py
+++ b/tests/pyiceberg_feature_tests.py
@@ -384,8 +384,28 @@ def test_type_promotion() -> TestResult:
 
 def test_column_default_values() -> TestResult:
     r = TestResult("column-default-values", "Column Default Values")
-    r.result = "fail"
-    r.details = "Column default values not supported in PyIceberg"
+    r.version_tested = "v3"
+    try:
+        from pyiceberg.types import NestedField
+
+        field_json = (
+            '{"id": 1, "name": "c", "type": "string", "required": false,'
+            ' "initial-default": "hello", "write-default": "world"}'
+        )
+        f = NestedField.model_validate_json(field_json)
+        assert f.initial_default == "hello"
+        assert f.write_default == "world"
+        roundtrip = json.loads(f.model_dump_json())
+        assert roundtrip.get("initial-default") == "hello"
+        assert roundtrip.get("write-default") == "world"
+        r.result = "pass"
+        r.details = (
+            "Parses and round-trips initial-default/write-default on schema fields; "
+            "applying defaults when writing data is pending V3 write support"
+        )
+    except Exception as e:
+        r.result = "fail"
+        r.details = f"Column default metadata not supported: {str(e).splitlines()[0][:120]}"
     return r
 
 
@@ -706,8 +726,46 @@ def test_nanosecond_timestamps() -> TestResult:
 
 def test_lineage() -> TestResult:
     r = TestResult("lineage", "Lineage Tracking")
-    r.result = "fail"
-    r.details = "PyIceberg does not support lineage tracking"
+    r.version_tested = "v3"
+    try:
+        from pyiceberg.table.metadata import TableMetadataUtil
+
+        v3_meta = {
+            "format-version": 3,
+            "table-uuid": "9c912b62-6bcd-4def-9dd2-c9ec9c4bec37",
+            "location": "s3://bucket/tbl",
+            "last-sequence-number": 1,
+            "last-updated-ms": 1700000000000,
+            "last-column-id": 1,
+            "schemas": [{"schema-id": 0, "type": "struct", "fields": [
+                {"id": 1, "name": "c", "type": "string", "required": False}]}],
+            "current-schema-id": 0,
+            "partition-specs": [{"spec-id": 0, "fields": []}],
+            "default-spec-id": 0,
+            "last-partition-id": 999,
+            "sort-orders": [{"order-id": 0, "fields": []}],
+            "default-sort-order-id": 0,
+            "properties": {},
+            "next-row-id": 100,
+            "snapshots": [{
+                "snapshot-id": 1, "sequence-number": 1,
+                "timestamp-ms": 1700000000000,
+                "manifest-list": "s3://bucket/ml.avro",
+                "summary": {"operation": "append"},
+                "schema-id": 0, "first-row-id": 0, "added-rows": 100,
+            }],
+        }
+        md = TableMetadataUtil.parse_obj(v3_meta)
+        assert md.next_row_id == 100
+        assert md.snapshots[0].first_row_id == 0
+        r.result = "pass"
+        r.details = (
+            "Reads V3 row lineage metadata (next-row-id, snapshot first-row-id); "
+            "assigning row IDs on write is pending V3 write support"
+        )
+    except Exception as e:
+        r.result = "fail"
+        r.details = f"V3 row lineage metadata not readable: {str(e).splitlines()[0][:120]}"
     return r
 
 


### PR DESCRIPTION
Hi! I cross-checked the PyIceberg column against the iceberg-python codebase and verified two V3 cells are stricter than the actual state (great site, by the way — I use it a lot):

- **Lineage Tracking (v3)**: PyIceberg reads V3 row lineage metadata — `next-row-id` on table metadata and `first-row-id` on snapshots/manifests (apache/iceberg-python#1821). Write-side row ID assignment is pending V3 write support, hence "partial".
- **Column Default Values (v3)**: `initial-default` / `write-default` are parsed and round-tripped (apache/iceberg-python#1644, apache/iceberg-python#1770). Applying defaults on write is pending V3 write support, hence "partial".

Both are verified against pyiceberg 0.11.1. I also replaced the two hardcoded fail stubs in `tests/pyiceberg_feature_tests.py` with real tests exercising the read support; the full suite passes with 0 discrepancies.

Heads-up for the near future: deletion vector write support is in review (apache/iceberg-python#3474), so the DV-related cells will need another look once it lands.

This pull request and its description were written by Isaac.
