### PR TITLE
ci: Install Python test deps with uv

### DIFF
--- a/.github/workflows/clickhouse-tests.yml
+++ b/.github/workflows/clickhouse-tests.yml
@@ -37,11 +37,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: tests/requirements.txt
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: tests/requirements.txt
 
       - name: Install Python dependencies
-        run: pip install -r tests/requirements.txt
+        run: uv pip install --system -r tests/requirements.txt
 
       - name: Download Iceberg Spark runtime JAR
         run: |

--- a/.github/workflows/duckdb-tests.yml
+++ b/.github/workflows/duckdb-tests.yml
@@ -23,8 +23,13 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+
       - name: Install DuckDB
-        run: pip install duckdb==1.5.4
+        run: uv pip install --system duckdb==1.5.4
 
       - name: Start Iceberg REST catalog (Apache iceberg-rest-fixture + MinIO)
         run: |

--- a/.github/workflows/iceberg-tests.yml
+++ b/.github/workflows/iceberg-tests.yml
@@ -37,12 +37,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: tests/requirements.txt
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: tests/requirements.txt
 
       - name: Install Python dependencies
         run: |
-          pip install -r tests/requirements.txt
+          uv pip install --system -r tests/requirements.txt
 
       - name: Download Iceberg Spark runtime JAR
         run: |

--- a/.github/workflows/pyiceberg-tests.yml
+++ b/.github/workflows/pyiceberg-tests.yml
@@ -28,8 +28,13 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+
       - name: Install PyIceberg
-        run: pip install 'pyiceberg[sql-sqlite,pyarrow]==0.11.1'
+        run: uv pip install --system 'pyiceberg[sql-sqlite,pyarrow]==0.11.1'
 
       - name: Run PyIceberg feature tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,9 @@ dist-ssr
 *.sln
 *.sw?
 tests/iceberg-spark-runtime-*.jar
+.venv/
 tests/venv/
 tests/flink-venv/
+__pycache__/
 tests/iceberg-flink-runtime-*.jar
 test-reports/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The repo includes a PySpark-based test suite that validates Iceberg features aga
 
 - Java 17
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) (dependency manager)
 - PySpark 4.1.2 (installed via `tests/requirements.txt`)
 
 > The suite exercises **both** Iceberg format-version 2 and version 3, so it
@@ -111,8 +112,9 @@ The repo includes a PySpark-based test suite that validates Iceberg features aga
 ### Local Execution
 
 ```bash
-# Install dependencies
-pip install -r tests/requirements.txt
+# Create the virtual environment and install dependencies
+uv venv --python 3.11
+uv pip install -r tests/requirements.txt
 
 # Download the Iceberg Spark 4.1 (Scala 2.13) runtime JAR
 ICEBERG_VERSION=1.11.0
@@ -121,7 +123,7 @@ curl -fSL -o "iceberg-spark-runtime-4.1_2.13-${ICEBERG_VERSION}.jar" \
 
 # Run the tests (auto-detects the JAR, or falls back to Maven coordinates).
 # Override the version with ICEBERG_VERSION=... if needed.
-python tests/iceberg_feature_tests.py
+uv run python tests/iceberg_feature_tests.py
 ```
 
 The suite also enforces **matrix coverage**: every feature defined in
@@ -134,7 +136,7 @@ Reports are written to `test-reports/` as both JSON and Markdown.
 ### CI
 
 Tests run automatically on pull requests via the **Iceberg Feature Tests** GitHub Actions workflow. The workflow:
-- Sets up Java 17, Python 3.11, PySpark, and the Iceberg runtime JAR
+- Sets up Java 17, Python 3.11 (deps installed with uv), PySpark, and the Iceberg runtime JAR
 - Runs all feature tests in Spark local mode
 - Uploads the report as a build artifact
 - Posts a summary comment on PRs

--- a/tests/clickhouse_feature_tests.py
+++ b/tests/clickhouse_feature_tests.py
@@ -12,7 +12,7 @@ Usage:
 Prerequisites:
     - clickhouse binary: curl https://clickhouse.com/install.sh | sh
     - Java 11+ (for PySpark)
-    - pip install pyspark pyiceberg[sql-sqlite,pyarrow]
+    - uv pip install pyspark pyiceberg[sql-sqlite,pyarrow]
 
 Environment variables:
     ICEBERG_WAREHOUSE   - Local warehouse path (default: ./clickhouse-iceberg-warehouse)
@@ -177,7 +177,7 @@ def _check_prerequisites() -> tuple[bool, bool, str]:
         msgs.append(f"ClickHouse not available (binary: {CLICKHOUSE_BINARY}). "
                     "Install: curl https://clickhouse.com/install.sh | sh")
     if not spark_ok:
-        msgs.append("PySpark not installed. Run: pip install pyspark")
+        msgs.append("PySpark not installed. Run: uv pip install pyspark")
     return ch_ok, spark_ok, "; ".join(msgs) if msgs else "OK"
 
 

--- a/tests/daft_feature_tests.py
+++ b/tests/daft_feature_tests.py
@@ -30,7 +30,7 @@ from pathlib import Path
 try:
     import daft
 except ImportError:
-    print("[FATAL] daft not installed. Run: pip install getdaft")
+    print("[FATAL] daft not installed. Run: uv pip install getdaft")
     sys.exit(1)
 
 try:
@@ -45,7 +45,7 @@ try:
     import pyarrow as pa
 except ImportError as e:
     print(f"[FATAL] Missing dependency: {e}")
-    print("Run: pip install 'pyiceberg[sql-sqlite,pyarrow]'")
+    print("Run: uv pip install 'pyiceberg[sql-sqlite,pyarrow]'")
     sys.exit(1)
 
 # ---------------------------------------------------------------------------

--- a/tests/duckdb_feature_tests.py
+++ b/tests/duckdb_feature_tests.py
@@ -46,7 +46,7 @@ from pathlib import Path
 try:
     import duckdb
 except ImportError:
-    print("[FATAL] duckdb not installed. Run: pip install duckdb==1.5.4")
+    print("[FATAL] duckdb not installed. Run: uv pip install duckdb==1.5.4")
     sys.exit(1)
 
 # ---------------------------------------------------------------------------

--- a/tests/pyiceberg_feature_tests.py
+++ b/tests/pyiceberg_feature_tests.py
@@ -41,7 +41,7 @@ try:
     import pyarrow as pa
 except ImportError as e:
     print(f"[FATAL] Missing dependency: {e}")
-    print("Run: pip install 'pyiceberg[sql-sqlite,pyarrow]'")
+    print("Run: uv pip install 'pyiceberg[sql-sqlite,pyarrow]'")
     sys.exit(1)
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replace pip with uv in the four workflows that install Python packages (Iceberg/Spark, ClickHouse, DuckDB, PyIceberg). Each now installs uv via astral-sh/setup-uv with the uv cache enabled and runs `uv pip install --system`, so pip's per-workflow cache config is no longer needed.

actions/setup-python still provides the interpreter, since it is cached alongside the runner and the test steps invoke `python` directly. The Flink workflow is untouched: that suite is stdlib-only and never installed dependencies.

Also switch the README local-run instructions to `uv venv` / `uv pip install` / `uv run`, update the pip hints in the test scripts' error messages, and ignore .venv/ and __pycache__/.

Pinned to setup-uv v9.0.0; Astral publishes immutable release tags, so there is no floating major tag to track.