### PR TITLE
test(aws): Add EMR Serverless platform tests on Iceberg

### DIFF
--- a/.github/workflows/aws-platform-tests.yml
+++ b/.github/workflows/aws-platform-tests.yml
@@ -1,0 +1,112 @@
+name: AWS Platform Tests
+
+# Runs the Iceberg feature suite against managed AWS engines and compares the
+# results with the matrix cells, the same way the OSS engine workflows do.
+#
+# Deliberately NOT triggered by pull_request: this spends real money and assumes
+# an IAM role. Dispatch only, gated by the aws-live environment (required
+# reviewer), and the OIDC trust policy is scoped to that environment so a token
+# minted anywhere else cannot assume the role.
+#
+# Only EMR Serverless is implemented. The engine input exists so Athena and Glue
+# can be added without restructuring; they fail fast until then.
+
+on:
+  workflow_dispatch:
+    inputs:
+      engine:
+        description: Engine to test
+        type: choice
+        default: emr-serverless
+        options:
+          - emr-serverless
+          - athena       # not implemented
+          - glue         # not implemented
+      modes:
+        description: Storage mode(s)
+        type: choice
+        default: both
+        options: [both, s3buckets, s3tables]
+      release-label:
+        description: EMR release label
+        type: string
+        default: emr-8.0.0
+      dry-run:
+        description: Assume the role and stop (proves OIDC without spending)
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Shared AWS resources: never let two runs overlap.
+  group: aws-live
+  cancel-in-progress: false
+
+jobs:
+  platform-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: aws-live
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      RUN_TAG: icebergmatrix-${{ github.run_id }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_DATA_BUCKET: ${{ secrets.AWS_DATA_BUCKET }}
+      AWS_EMR_JOB_ROLE_ARN: ${{ secrets.AWS_EMR_JOB_ROLE_ARN }}
+      AWS_TABLE_BUCKET_ARN: ${{ secrets.AWS_TABLE_BUCKET_ARN }}
+      RESOURCE_PREFIX: icebergmatrix
+      ENGINE: emr
+
+    steps:
+      - name: Reject unimplemented engines
+        if: inputs.engine != 'emr-serverless'
+        run: |
+          echo "::error::'${{ inputs.engine }}' is not implemented yet; only emr-serverless is."
+          exit 1
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Verify assumed identity
+        run: aws sts get-caller-identity
+
+      - name: Stop here on dry run
+        if: inputs.dry-run
+        run: 'echo "Dry run complete: OIDC trust and environment gate verified, nothing provisioned."'
+
+      # No continue-on-error: the driver exits non-zero when a job run fails or
+      # a report contains discrepancies or errors, and that should fail the job.
+      # Teardown still runs because it is guarded with always().
+      - name: Run feature suite on EMR Serverless
+        if: '!inputs.dry-run'
+        env:
+          MODES: ${{ inputs.modes }}
+          EMR_RELEASE_LABEL: ${{ inputs.release-label }}
+        run: uv run --with boto3 python tests/aws/run_emr_serverless.py
+
+      - name: Tear down billable resources
+        if: always() && !inputs.dry-run
+        run: uv run --with boto3 python tests/aws/teardown.py
+
+      - name: Upload reports
+        if: always() && !inputs.dry-run
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-emr-platform-test-report
+          path: test-reports/
+          if-no-files-found: warn

--- a/infra/aws/README.MD
+++ b/infra/aws/README.MD
@@ -1,0 +1,20 @@
+You should create a s3 bucket and s3 table bucket first. Then deploy the template. 
+
+```
+aws cloudformation deploy \
+  --stack-name icebergmatrix-ci \
+  --template-file tests/aws/bootstrap.yaml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+      DataBucket=<your-bucket> \
+      TableBucketArn=arn:aws:s3tables:<region>:<acct>:bucket/<name> \
+      BudgetNotificationEmail=you@example.com```
+```
+
+Next, configure a lifecycle for the bucket. 
+
+```
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket iceberg-tests-matrix \
+  --lifecycle-configuration file://infra/s3-lifecycle.json
+```

--- a/infra/aws/aws.yaml
+++ b/infra/aws/aws.yaml
@@ -1,0 +1,286 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  OIDC trust and IAM roles for iceberg-matrix platform tests on EMR Serverless.
+  Creates a CI role assumed by GitHub Actions via OIDC (scoped to a single
+  GitHub environment) and a job execution role assumed by EMR Serverless.
+  Deploy with: --capabilities CAPABILITY_NAMED_IAM
+
+Parameters:
+  GitHubRepo:
+    Type: String
+    Default: Neuw84/iceberg-matrix
+    Description: owner/repo allowed to assume the CI role
+  EnvironmentName:
+    Type: String
+    Default: aws-live
+    Description: >
+      GitHub environment name. Must match the environment used by the workflow
+      job: the OIDC subject claim is scoped to it, so tokens minted from any
+      other context (pull requests, other branches) cannot assume the role.
+  DataBucket:
+    Type: String
+    Description: Existing S3 bucket for warehouse data, job scripts, logs and reports
+  TableBucketArn:
+    Type: String
+    Description: Existing S3 Tables bucket ARN, e.g. arn:aws:s3tables:eu-west-1:123456789012:bucket/my-tables
+  ResourcePrefix:
+    Type: String
+    Default: icebergmatrix
+    Description: Prefix for created Glue databases and S3 Tables namespaces; IAM is scoped to it
+  ExistingOidcProviderArn:
+    Type: String
+    Default: ''
+    Description: >
+      Leave empty to create the GitHub OIDC provider. If your account already
+      has one, paste its ARN here (a second provider for the same URL fails).
+  MonthlyBudgetUsd:
+    Type: Number
+    Default: 20
+    Description: Monthly cost budget for the account
+  BudgetNotificationEmail:
+    Type: String
+    Default: ''
+    Description: Optional email for budget alerts at 80% of the limit
+
+Conditions:
+  CreateOidcProvider: !Equals [!Ref ExistingOidcProviderArn, '']
+  HasBudgetEmail: !Not [!Equals [!Ref BudgetNotificationEmail, '']]
+
+Resources:
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions OIDC provider. Both thumbprints are GitHub's published
+  # intermediate CA fingerprints; IAM validates the chain itself, but the
+  # property is expected here.
+  # ---------------------------------------------------------------------------
+  GitHubOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Condition: CreateOidcProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
+
+  # ---------------------------------------------------------------------------
+  # Job execution role: assumed by EMR Serverless, not by GitHub. This is the
+  # identity that actually reads and writes table data.
+  # ---------------------------------------------------------------------------
+  EmrJobRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${ResourcePrefix}-emr-job'
+      Description: Execution role for iceberg-matrix EMR Serverless jobs
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: emr-serverless.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                'aws:SourceAccount': !Ref AWS::AccountId
+      Policies:
+
+        - PolicyName: s3-data-access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource: !Sub 'arn:${AWS::Partition}:s3:::${DataBucket}/*'
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                  - s3:GetBucketLocation
+                Resource: !Sub 'arn:${AWS::Partition}:s3:::${DataBucket}'
+
+        # Glue Data Catalog as the Iceberg catalog for the s3buckets mode.
+        - PolicyName: glue-catalog-access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - glue:GetDatabase
+                  - glue:GetDatabases
+                  - glue:CreateDatabase
+                  - glue:DeleteDatabase
+                  - glue:GetTable
+                  - glue:GetTables
+                  - glue:CreateTable
+                  - glue:UpdateTable
+                  - glue:DeleteTable
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog'
+                  - !Sub 'arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${ResourcePrefix}*'
+                  - !Sub 'arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}*/*'
+
+        # S3 Tables as the Iceberg catalog for the s3tables mode. Deliberately
+        # broad on the one table bucket for the first runs; narrow this once you
+        # have seen which calls the writes actually make.
+        - PolicyName: s3tables-access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3tables:*
+                Resource:
+                  - !Ref TableBucketArn
+                  - !Sub '${TableBucketArn}/*'
+
+  # ---------------------------------------------------------------------------
+  # CI role: assumed by GitHub Actions via OIDC. Drives EMR Serverless and
+  # cleans up afterwards. It never touches table data directly.
+  # ---------------------------------------------------------------------------
+  CiRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${ResourcePrefix}-ci'
+      Description: Assumed by GitHub Actions to run iceberg-matrix platform tests
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !If
+                - CreateOidcProvider
+                - !Ref GitHubOidcProvider
+                - !Ref ExistingOidcProviderArn
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                'token.actions.githubusercontent.com:aud': sts.amazonaws.com
+                # Environment-scoped: this is the enforcement point.
+                'token.actions.githubusercontent.com:sub': !Sub 'repo:${GitHubRepo}:environment:${EnvironmentName}'
+      Policies:
+
+        - PolicyName: drive-emr-serverless
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # CreateApplication and List* cannot be scoped to a resource.
+              - Effect: Allow
+                Action:
+                  - emr-serverless:CreateApplication
+                  - emr-serverless:ListApplications
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - emr-serverless:GetApplication
+                  - emr-serverless:StartApplication
+                  - emr-serverless:StopApplication
+                  - emr-serverless:DeleteApplication
+                  - emr-serverless:TagResource
+                  - emr-serverless:UntagResource
+                  - emr-serverless:StartJobRun
+                  - emr-serverless:GetJobRun
+                  - emr-serverless:ListJobRuns
+                  - emr-serverless:CancelJobRun
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:emr-serverless:${AWS::Region}:${AWS::AccountId}:/applications/*'
+
+              # Hand the job role to EMR Serverless, and nothing else.
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource: !GetAtt EmrJobRole.Arn
+                Condition:
+                  StringEquals:
+                    'iam:PassedToService': emr-serverless.amazonaws.com
+
+        - PolicyName: s3-scripts-and-reports
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource: !Sub 'arn:${AWS::Partition}:s3:::${DataBucket}/*'
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                  - s3:GetBucketLocation
+                Resource: !Sub 'arn:${AWS::Partition}:s3:::${DataBucket}'
+
+        # Teardown of catalog objects the job created. Read + delete only:
+        # the CI role must not be able to create tables.
+        - PolicyName: teardown-catalog-objects
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - glue:GetDatabase
+                  - glue:GetDatabases
+                  - glue:GetTable
+                  - glue:GetTables
+                  - glue:DeleteTable
+                  - glue:DeleteDatabase
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog'
+                  - !Sub 'arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${ResourcePrefix}*'
+                  - !Sub 'arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}*/*'
+              - Effect: Allow
+                Action:
+                  - s3tables:GetTableBucket
+                  - s3tables:ListNamespaces
+                  - s3tables:GetNamespace
+                  - s3tables:ListTables
+                  - s3tables:GetTable
+                  - s3tables:GetTableMetadataLocation
+                  - s3tables:DeleteTable
+                  - s3tables:DeleteNamespace
+                Resource:
+                  - !Ref TableBucketArn
+                  - !Sub '${TableBucketArn}/*'
+
+  # ---------------------------------------------------------------------------
+  # Cost guard. Not a limit, only an alarm: AWS budgets cannot stop spend.
+  # ---------------------------------------------------------------------------
+  CostGuard:
+    Type: AWS::Budgets::Budget
+    Properties:
+      Budget:
+        BudgetName: !Sub '${ResourcePrefix}-ci'
+        BudgetType: COST
+        TimeUnit: MONTHLY
+        BudgetLimit:
+          Amount: !Ref MonthlyBudgetUsd
+          Unit: USD
+      NotificationsWithSubscribers: !If
+        - HasBudgetEmail
+        - - Notification:
+              NotificationType: ACTUAL
+              ComparisonOperator: GREATER_THAN
+              Threshold: 80
+              ThresholdType: PERCENTAGE
+            Subscribers:
+              - SubscriptionType: EMAIL
+                Address: !Ref BudgetNotificationEmail
+        - !Ref AWS::NoValue
+
+Outputs:
+  CiRoleArn:
+    Description: Set as the AWS_CI_ROLE_ARN environment secret in GitHub
+    Value: !GetAtt CiRole.Arn
+  EmrJobRoleArn:
+    Description: Set as the AWS_EMR_JOB_ROLE_ARN environment secret in GitHub
+    Value: !GetAtt EmrJobRole.Arn
+  DataBucketName:
+    Description: Set as the AWS_DATA_BUCKET environment secret in GitHub
+    Value: !Ref DataBucket
+  TableBucketArnOut:
+    Description: Set as the AWS_TABLE_BUCKET_ARN environment secret in GitHub
+    Value: !Ref TableBucketArn
+  ResourcePrefixOut:
+    Description: Glue databases and S3 Tables namespaces must start with this
+    Value: !Ref ResourcePrefix

--- a/infra/aws/s3-lifecycle.json
+++ b/infra/aws/s3-lifecycle.json
@@ -1,0 +1,44 @@
+{
+  "Rules": [
+    {
+      "ID": "abort-incomplete-multipart-uploads",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "" },
+      "AbortIncompleteMultipartUpload": { "DaysAfterInitiation": 1 }
+    },
+    {
+      "ID": "clean-noncurrent-versions-and-delete-markers",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "" },
+      "NoncurrentVersionExpiration": { "NoncurrentDays": 1 },
+      "Expiration": { "ExpiredObjectDeleteMarker": true }
+    },
+
+    { "ID": "emr-warehouse-1d", "Status": "Enabled",
+      "Filter": { "Prefix": "emr/warehouse/" }, "Expiration": { "Days": 1 } },
+    { "ID": "emr-logs-1d", "Status": "Enabled",
+      "Filter": { "Prefix": "emr/logs/" }, "Expiration": { "Days": 1 } },
+    { "ID": "emr-scripts-7d", "Status": "Enabled",
+      "Filter": { "Prefix": "emr/scripts/" }, "Expiration": { "Days": 7 } },
+    { "ID": "emr-reports-30d", "Status": "Enabled",
+      "Filter": { "Prefix": "emr/reports/" }, "Expiration": { "Days": 30 } },
+
+    { "ID": "glue-warehouse-1d", "Status": "Enabled",
+      "Filter": { "Prefix": "glue/warehouse/" }, "Expiration": { "Days": 1 } },
+    { "ID": "glue-logs-1d", "Status": "Enabled",
+      "Filter": { "Prefix": "glue/logs/" }, "Expiration": { "Days": 1 } },
+    { "ID": "glue-scripts-7d", "Status": "Enabled",
+      "Filter": { "Prefix": "glue/scripts/" }, "Expiration": { "Days": 7 } },
+    { "ID": "glue-reports-30d", "Status": "Enabled",
+      "Filter": { "Prefix": "glue/reports/" }, "Expiration": { "Days": 30 } },
+
+    { "ID": "athena-warehouse-1d", "Status": "Enabled",
+      "Filter": { "Prefix": "athena/warehouse/" }, "Expiration": { "Days": 1 } },
+    { "ID": "athena-results-1d", "Status": "Enabled",
+      "Filter": { "Prefix": "athena/results/" }, "Expiration": { "Days": 1 } },
+    { "ID": "athena-scripts-7d", "Status": "Enabled",
+      "Filter": { "Prefix": "athena/scripts/" }, "Expiration": { "Days": 7 } },
+    { "ID": "athena-reports-30d", "Status": "Enabled",
+      "Filter": { "Prefix": "athena/reports/" }, "Expiration": { "Days": 30 } }
+  ]
+}

--- a/tests/aws/emr_entrypoint.py
+++ b/tests/aws/emr_entrypoint.py
@@ -1,0 +1,117 @@
+"""EMR Serverless entry point: run the Spark feature suite against an AWS catalog.
+
+Submitted by tests/aws/run_emr_serverless.py as the spark-submit entry point.
+This runs *inside* the EMR Serverless job, so it must not assume anything about
+the repo being present: it pulls a bundle (the suite plus the matrix data) from
+S3, points the suite at the right catalog and matrix cells, then uploads the
+resulting report back to S3.
+
+The suite itself is unmodified -- the same 70 checks that run against OSS Spark
+run here, which is the whole reason for choosing EMR as the first platform.
+
+Arguments (all required, passed as entryPointArguments):
+    --bundle s3://bucket/emr/scripts/<run>/bundle.zip
+    --report-uri s3://bucket/emr/reports/<run>/<mode>/
+    --mode s3buckets|s3tables
+    --catalog-impl <iceberg catalog-impl class>
+    --warehouse <warehouse location or table bucket ARN>
+    --ns-prefix <namespace prefix the job role is allowed to create>
+    --platform-label "<release label> / <mode>"
+"""
+
+import argparse
+import os
+import runpy
+import sys
+import zipfile
+from urllib.parse import urlparse
+
+WORK_DIR = "/tmp/icebergmatrix"
+REPORT_DIR = os.path.join(WORK_DIR, "reports")
+
+
+def _split_s3(uri: str):
+    parsed = urlparse(uri)
+    return parsed.netloc, parsed.path.lstrip("/")
+
+
+def fetch_bundle(bundle_uri: str, dest_dir: str) -> str:
+    """Download and unpack the repo bundle. Returns the extracted repo root."""
+    import boto3
+
+    bucket, key = _split_s3(bundle_uri)
+    local_zip = os.path.join(WORK_DIR, "bundle.zip")
+    os.makedirs(WORK_DIR, exist_ok=True)
+    boto3.client("s3").download_file(bucket, key, local_zip)
+    with zipfile.ZipFile(local_zip) as zf:
+        zf.extractall(dest_dir)
+    print(f"[entrypoint] bundle extracted to {dest_dir}")
+    return dest_dir
+
+
+def upload_reports(report_uri: str) -> None:
+    import boto3
+
+    bucket, prefix = _split_s3(report_uri)
+    s3 = boto3.client("s3")
+    if not os.path.isdir(REPORT_DIR):
+        print(f"[entrypoint] no reports at {REPORT_DIR}")
+        return
+    for name in sorted(os.listdir(REPORT_DIR)):
+        local = os.path.join(REPORT_DIR, name)
+        if os.path.isfile(local):
+            key = f"{prefix.rstrip('/')}/{name}"
+            s3.upload_file(local, bucket, key)
+            print(f"[entrypoint] uploaded s3://{bucket}/{key}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--bundle", required=True)
+    p.add_argument("--report-uri", required=True)
+    p.add_argument("--mode", required=True, choices=["s3buckets", "s3tables"])
+    p.add_argument("--catalog-impl", required=True)
+    p.add_argument("--warehouse", required=True)
+    p.add_argument("--ns-prefix", default="icebergmatrix_")
+    p.add_argument("--platform-label", default="")
+    args = p.parse_args()
+
+    repo_root = fetch_bundle(args.bundle, os.path.join(WORK_DIR, "repo"))
+    os.makedirs(REPORT_DIR, exist_ok=True)
+
+    os.environ.update({
+        "REPO_ROOT": repo_root,
+        "REPORT_DIR": REPORT_DIR,
+        "ICEBERG_WAREHOUSE": os.path.join(WORK_DIR, "hadoop-warehouse"),
+        # Compare against the AWS EMR cells for this storage mode.
+        "MATRIX_PLATFORM_ID": "aws-emr",
+        "MATRIX_DATA_PATH": f"src/data/platforms/aws/{args.mode}/emr/emr.json",
+        "MATRIX_NS_PREFIX": args.ns_prefix,
+        "PLATFORM_LABEL": args.platform_label,
+        # Platform catalog: no REST, no jar wiring, no master override.
+        "ICEBERG_CATALOG_IMPL": args.catalog_impl,
+        "ICEBERG_CATALOG_WAREHOUSE": args.warehouse,
+        "ICEBERG_REST_URI": "",
+    })
+
+    suite = os.path.join(repo_root, "tests", "iceberg_feature_tests.py")
+    print(f"[entrypoint] running {suite} (mode={args.mode})")
+
+    exit_code = 0
+    try:
+        # The suite calls sys.exit() to signal discrepancies; that is a result,
+        # not a failure of this job, so capture it and keep going to the upload.
+        runpy.run_path(suite, run_name="__main__")
+    except SystemExit as e:
+        exit_code = int(e.code or 0)
+    finally:
+        upload_reports(args.report_uri)
+
+    print(f"[entrypoint] suite exit code: {exit_code}")
+    # Always exit 0: a discrepancy is data, and failing the job run would only
+    # obscure the report the driver is about to read.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/aws/run_emr_serverless.py
+++ b/tests/aws/run_emr_serverless.py
@@ -1,0 +1,323 @@
+"""Run the Iceberg feature suite on AWS EMR Serverless, both storage modes.
+
+Creates an ephemeral EMR Serverless application, submits one Spark job per
+storage mode (S3 buckets via the Glue catalog, and S3 Tables), downloads the
+reports and prints them in the same shape the OSS engine suites produce.
+
+Everything lives under a per-engine prefix in the data bucket so the other
+platforms can be added alongside without collisions:
+
+    s3://<bucket>/emr/scripts/<run>/     entry point + repo bundle
+    s3://<bucket>/emr/warehouse/<run>/   table data (s3buckets mode)
+    s3://<bucket>/emr/logs/<run>/        EMR Serverless job logs
+    s3://<bucket>/emr/reports/<run>/     JSON + markdown reports
+
+The application has no pre-initialized capacity, so it costs nothing while
+idle; billing is per job vCPU/memory-hour. tests/aws/teardown.py removes it
+along with everything else billable.
+
+Environment:
+    AWS_REGION            (required)
+    AWS_DATA_BUCKET       (required) S3 bucket for scripts/warehouse/logs/reports
+    AWS_EMR_JOB_ROLE_ARN  (required) execution role passed to EMR Serverless
+    AWS_TABLE_BUCKET_ARN  (required for s3tables mode)
+    RUN_TAG               (required) unique per run, e.g. icebergmatrix-<run_id>
+    MODES                 both|s3buckets|s3tables      (default: both)
+    EMR_RELEASE_LABEL     (default: emr-8.0.0)
+    RESOURCE_PREFIX       (default: icebergmatrix) must match the IAM scope
+    JOB_TIMEOUT_MINUTES   (default: 30)
+"""
+
+import json
+import os
+import sys
+import time
+import zipfile
+from pathlib import Path
+
+import boto3
+
+REGION = os.environ["AWS_REGION"]
+DATA_BUCKET = os.environ["AWS_DATA_BUCKET"]
+JOB_ROLE_ARN = os.environ["AWS_EMR_JOB_ROLE_ARN"]
+TABLE_BUCKET_ARN = os.environ.get("AWS_TABLE_BUCKET_ARN", "")
+RUN_TAG = os.environ["RUN_TAG"]
+MODES = os.environ.get("MODES", "both")
+RELEASE_LABEL = os.environ.get("EMR_RELEASE_LABEL", "emr-8.0.0")
+RESOURCE_PREFIX = os.environ.get("RESOURCE_PREFIX", "icebergmatrix")
+JOB_TIMEOUT_MINUTES = int(os.environ.get("JOB_TIMEOUT_MINUTES", "30"))
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LOCAL_REPORT_DIR = REPO_ROOT / "test-reports"
+ENGINE = "emr"
+
+# Iceberg ships inside the EMR image; this is a local path in the container, not
+# a download. See the EMR Serverless "Using Apache Iceberg" documentation.
+ICEBERG_JAR = "/usr/share/aws/iceberg/lib/iceberg-spark3-runtime.jar"
+
+# Catalog implementations per storage mode.
+GLUE_CATALOG_IMPL = "org.apache.iceberg.aws.glue.GlueCatalog"
+# NOTE: unverified against EMR 8.0. If the s3tables job fails to resolve this
+# class, override with S3TABLES_CATALOG_IMPL and add the client jar via
+# S3TABLES_EXTRA_JARS.
+S3TABLES_CATALOG_IMPL = os.environ.get(
+    "S3TABLES_CATALOG_IMPL", "software.amazon.s3tables.iceberg.S3TablesCatalog"
+)
+S3TABLES_EXTRA_JARS = os.environ.get("S3TABLES_EXTRA_JARS", "")
+
+emr = boto3.client("emr-serverless", region_name=REGION)
+s3 = boto3.client("s3", region_name=REGION)
+
+
+def s3_uri(*parts: str) -> str:
+    return f"s3://{DATA_BUCKET}/" + "/".join(p.strip("/") for p in parts)
+
+
+def build_bundle(dest: Path) -> Path:
+    """Zip the suite and the matrix data the suite needs to compare against."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    includes = [REPO_ROOT / "tests" / "iceberg_feature_tests.py",
+                REPO_ROOT / "src" / "data" / "features.json"]
+    for mode in ("s3buckets", "s3tables"):
+        includes.append(REPO_ROOT / "src" / "data" / "platforms" / "aws" / mode / "emr" / "emr.json")
+
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in includes:
+            if not path.is_file():
+                raise FileNotFoundError(f"bundle input missing: {path}")
+            zf.write(path, path.relative_to(REPO_ROOT).as_posix())
+    print(f"[driver] bundle: {dest} ({dest.stat().st_size // 1024} KiB)")
+    return dest
+
+
+def upload(local: Path, key: str) -> str:
+    s3.upload_file(str(local), DATA_BUCKET, key)
+    uri = f"s3://{DATA_BUCKET}/{key}"
+    print(f"[driver] uploaded {uri}")
+    return uri
+
+
+def create_application() -> str:
+    name = f"{RESOURCE_PREFIX}-{RUN_TAG}"[:64]
+    print(f"[driver] creating application {name} ({RELEASE_LABEL})")
+    resp = emr.create_application(
+        name=name,
+        releaseLabel=RELEASE_LABEL,
+        type="SPARK",
+        clientToken=RUN_TAG[:64],
+        # No initialCapacity: nothing is pre-warmed, so idle cost is zero.
+        autoStartConfiguration={"enabled": True},
+        autoStopConfiguration={"enabled": True, "idleTimeoutMinutes": 5},
+        maximumCapacity={"cpu": "8 vCPU", "memory": "32 GB", "disk": "60 GB"},
+        tags={"project": "iceberg-matrix", "run": RUN_TAG},
+    )
+    app_id = resp["applicationId"]
+    _wait_for(lambda: emr.get_application(applicationId=app_id)["application"]["state"],
+              want={"CREATED", "STARTED"}, bad={"TERMINATED"}, what=f"application {app_id}")
+    print(f"[driver] application ready: {app_id}")
+    return app_id
+
+
+def _wait_for(get_state, want: set, bad: set, what: str, timeout_s: int = 600) -> str:
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        state = get_state()
+        if state != last:
+            print(f"[driver] {what}: {state}")
+            last = state
+        if state in want:
+            return state
+        if state in bad:
+            raise RuntimeError(f"{what} entered {state}")
+        time.sleep(10)
+    raise TimeoutError(f"{what} still {last} after {timeout_s}s")
+
+
+def spark_submit_params(mode: str, catalog_impl: str, warehouse: str) -> str:
+    jars = ICEBERG_JAR
+    if mode == "s3tables" and S3TABLES_EXTRA_JARS:
+        jars = f"{jars},{S3TABLES_EXTRA_JARS}"
+
+    params = [
+        f"--conf spark.jars={jars}",
+        "--conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+        "--conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog",
+        f"--conf spark.sql.catalog.local.catalog-impl={catalog_impl}",
+        f"--conf spark.sql.catalog.local.warehouse={warehouse}",
+        "--conf spark.sql.defaultCatalog=local",
+    ]
+    if mode == "s3buckets":
+        params.append(
+            "--conf spark.hadoop.hive.metastore.client.factory.class="
+            "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+        )
+    return " ".join(params)
+
+
+def run_mode(app_id: str, mode: str, bundle_uri: str, entry_uri: str) -> dict:
+    if mode == "s3buckets":
+        catalog_impl = GLUE_CATALOG_IMPL
+        warehouse = s3_uri(ENGINE, "warehouse", RUN_TAG) + "/"
+    else:
+        if not TABLE_BUCKET_ARN:
+            raise SystemExit("AWS_TABLE_BUCKET_ARN is required for the s3tables mode")
+        catalog_impl = S3TABLES_CATALOG_IMPL
+        warehouse = TABLE_BUCKET_ARN
+
+    report_uri = s3_uri(ENGINE, "reports", RUN_TAG, mode) + "/"
+    print(f"\n[driver] === {mode}: {catalog_impl} -> {warehouse} ===")
+
+    resp = emr.start_job_run(
+        applicationId=app_id,
+        executionRoleArn=JOB_ROLE_ARN,
+        name=f"{RESOURCE_PREFIX}-{mode}"[:64],
+        executionTimeoutMinutes=JOB_TIMEOUT_MINUTES,
+        jobDriver={
+            "sparkSubmit": {
+                "entryPoint": entry_uri,
+                "entryPointArguments": [
+                    "--bundle", bundle_uri,
+                    "--report-uri", report_uri,
+                    "--mode", mode,
+                    "--catalog-impl", catalog_impl,
+                    "--warehouse", warehouse,
+                    "--ns-prefix", f"{RESOURCE_PREFIX}_",
+                    "--platform-label", f"{RELEASE_LABEL} / {mode}",
+                ],
+                "sparkSubmitParameters": spark_submit_params(mode, catalog_impl, warehouse),
+            }
+        },
+        configurationOverrides={
+            "monitoringConfiguration": {
+                "s3MonitoringConfiguration": {"logUri": s3_uri(ENGINE, "logs", RUN_TAG) + "/"}
+            }
+        },
+        tags={"project": "iceberg-matrix", "run": RUN_TAG, "mode": mode},
+    )
+    job_id = resp["jobRunId"]
+
+    state = _wait_for(
+        lambda: emr.get_job_run(applicationId=app_id, jobRunId=job_id)["jobRun"]["state"],
+        want={"SUCCESS", "FAILED", "CANCELLED"}, bad=set(),
+        what=f"job {job_id} ({mode})", timeout_s=JOB_TIMEOUT_MINUTES * 60 + 300,
+    )
+    details = emr.get_job_run(applicationId=app_id, jobRunId=job_id)["jobRun"]
+    if state != "SUCCESS":
+        print(f"[driver] job {job_id} {state}: {details.get('stateDetails', '')}")
+        print(f"[driver] logs: {s3_uri(ENGINE, 'logs', RUN_TAG)}/applications/{app_id}/jobs/{job_id}/")
+    return {"mode": mode, "job_run_id": job_id, "state": state,
+            "state_details": details.get("stateDetails", ""), "report_uri": report_uri}
+
+
+def download_reports(mode: str) -> Path | None:
+    """Pull the report this mode produced into test-reports/, OSS-style names."""
+    prefix = f"{ENGINE}/reports/{RUN_TAG}/{mode}/"
+    listing = s3.list_objects_v2(Bucket=DATA_BUCKET, Prefix=prefix).get("Contents", [])
+    if not listing:
+        print(f"[driver] no report objects under s3://{DATA_BUCKET}/{prefix}")
+        return None
+
+    LOCAL_REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    json_path = None
+    for obj in listing:
+        name = obj["Key"].rsplit("/", 1)[-1]
+        # emr-s3buckets-iceberg-test-report.json / .md
+        local = LOCAL_REPORT_DIR / f"{ENGINE}-{mode}-{name}"
+        s3.download_file(DATA_BUCKET, obj["Key"], str(local))
+        print(f"[driver] report: {local.relative_to(REPO_ROOT)}")
+        if local.suffix == ".json":
+            json_path = local
+    return json_path
+
+
+def summarise(results: list, reports: dict) -> int:
+    """Print the same summary the OSS suites print, and mirror it to the job summary."""
+    lines = ["# AWS EMR Serverless Iceberg Feature Test Report", "",
+             f"- **Release:** {RELEASE_LABEL}", f"- **Run:** {RUN_TAG}", ""]
+    worst = 0
+
+    for r in results:
+        rep = reports.get(r["mode"])
+        lines.append(f"## {r['mode']}")
+        lines.append("")
+        if r["state"] != "SUCCESS":
+            lines.append(f"Job run {r['state']}: {r['state_details']}")
+            lines.append("")
+            worst = max(worst, 1)
+            continue
+        if not rep:
+            lines.append("Job succeeded but produced no report.")
+            lines.append("")
+            worst = max(worst, 1)
+            continue
+
+        s = rep["summary"]
+        lines += [
+            f"- **Catalog:** {rep.get('catalog_mode', '')}",
+            f"- **Spark:** {rep.get('spark_version', '')} | **Iceberg:** {rep.get('iceberg_version', '')}",
+            "",
+            "| Metric | Count |", "|--------|-------|",
+            f"| Total | {s['total']} |",
+            f"| Passed | {s['passed']} |",
+            f"| Failed | {s['failed']} |",
+            f"| Skipped | {s['skipped']} |",
+            f"| Errors | {s['errors']} |",
+            f"| Discrepancies | {s['discrepancies']} |",
+            "",
+        ]
+        discs = [t for t in rep["tests"] if not t["match"]]
+        if discs:
+            lines.append("### Discrepancies")
+            lines.append("")
+            for t in discs:
+                lines.append(f"- **{t['feature_name']}** ({t['version']}): "
+                             f"test={t['result']}, json={t['json_level']} — {t['details'][:160]}")
+            lines.append("")
+        if s["discrepancies"] or s["errors"]:
+            worst = max(worst, 1)
+
+    text = "\n".join(lines)
+    print("\n" + text)
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write(text + "\n")
+    return worst
+
+
+def main() -> int:
+    modes = ["s3buckets", "s3tables"] if MODES == "both" else [MODES]
+    print(f"[driver] region={REGION} bucket={DATA_BUCKET} modes={modes}")
+
+    bundle = build_bundle(Path("/tmp") / f"{RUN_TAG}-bundle.zip")
+    bundle_uri = upload(bundle, f"{ENGINE}/scripts/{RUN_TAG}/bundle.zip")
+    entry_uri = upload(Path(__file__).with_name("emr_entrypoint.py"),
+                       f"{ENGINE}/scripts/{RUN_TAG}/emr_entrypoint.py")
+
+    app_id = create_application()
+    # Record the application id so teardown can find it even if we crash.
+    Path("/tmp/emr-application-id").write_text(app_id)
+    if os.environ.get("GITHUB_ENV"):
+        with open(os.environ["GITHUB_ENV"], "a") as f:
+            f.write(f"EMR_APPLICATION_ID={app_id}\n")
+
+    results, reports = [], {}
+    for mode in modes:
+        try:
+            r = run_mode(app_id, mode, bundle_uri, entry_uri)
+        except Exception as e:  # noqa: BLE001 - one mode failing must not hide the other
+            print(f"[driver] {mode} raised: {type(e).__name__}: {e}")
+            results.append({"mode": mode, "job_run_id": "", "state": "DRIVER_ERROR",
+                            "state_details": str(e)[:300], "report_uri": ""})
+            continue
+        results.append(r)
+        path = download_reports(mode)
+        if path:
+            reports[mode] = json.loads(path.read_text())
+
+    return summarise(results, reports)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/aws/teardown.py
+++ b/tests/aws/teardown.py
@@ -1,0 +1,211 @@
+"""Delete everything billable that a platform test run created.
+
+Runs with `if: always()` so it must never raise: every step is best-effort and
+reports what it did. Anything it cannot remove is printed loudly, because the
+alternative is silent spend.
+
+Order matters. Job runs are cancelled before the application is stopped, and the
+application is stopped before it is deleted, otherwise the delete is rejected.
+
+What is billable, and therefore what this removes:
+  - EMR Serverless job runs      billed per vCPU/memory-hour while RUNNING
+  - EMR Serverless application   free while idle (no pre-init capacity), removed anyway
+  - S3 objects                   warehouse data, logs, scripts
+  - Glue databases and tables    catalog storage and requests
+  - S3 Tables namespaces/tables  storage plus automatic maintenance, which bills
+                                 even when nobody queries -- so tables must be
+                                 deleted, not just emptied
+
+Reports under <engine>/reports/<run>/ are kept deliberately: they are tiny and
+they are the output of the run. The S3 lifecycle rules expire them later.
+
+Environment: AWS_REGION, AWS_DATA_BUCKET, RUN_TAG,
+             AWS_TABLE_BUCKET_ARN (optional), EMR_APPLICATION_ID (optional),
+             RESOURCE_PREFIX (default: icebergmatrix), ENGINE (default: emr)
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+DATA_BUCKET = os.environ.get("AWS_DATA_BUCKET", "")
+TABLE_BUCKET_ARN = os.environ.get("AWS_TABLE_BUCKET_ARN", "")
+RUN_TAG = os.environ.get("RUN_TAG", "")
+RESOURCE_PREFIX = os.environ.get("RESOURCE_PREFIX", "icebergmatrix")
+ENGINE = os.environ.get("ENGINE", "emr")
+
+problems: list[str] = []
+
+
+def note(msg: str) -> None:
+    print(f"[teardown] {msg}")
+
+
+def failed(what: str, e: Exception) -> None:
+    msg = f"{what}: {type(e).__name__}: {e}"
+    problems.append(msg)
+    print(f"[teardown] COULD NOT CLEAN {msg}")
+
+
+def application_id() -> str:
+    app_id = os.environ.get("EMR_APPLICATION_ID", "")
+    if app_id:
+        return app_id
+    marker = Path("/tmp/emr-application-id")
+    return marker.read_text().strip() if marker.is_file() else ""
+
+
+def kill_emr(app_id: str) -> None:
+    if not app_id:
+        note("no EMR application id recorded; skipping (check the console if a run was started)")
+        return
+    emr = boto3.client("emr-serverless", region_name=REGION)
+
+    live = {"SUBMITTED", "PENDING", "SCHEDULED", "RUNNING"}
+    try:
+        runs = emr.list_job_runs(applicationId=app_id, states=list(live)).get("jobRuns", [])
+        for run in runs:
+            note(f"cancelling job run {run['id']} ({run['state']})")
+            emr.cancel_job_run(applicationId=app_id, jobRunId=run["id"])
+        for run in runs:  # wait so the stop below is not rejected
+            for _ in range(30):
+                state = emr.get_job_run(applicationId=app_id, jobRunId=run["id"])["jobRun"]["state"]
+                if state not in live and state != "CANCELLING":
+                    break
+                time.sleep(5)
+    except ClientError as e:
+        failed(f"cancel job runs on {app_id}", e)
+
+    try:
+        state = emr.get_application(applicationId=app_id)["application"]["state"]
+        if state in {"STARTED", "STARTING"}:
+            note(f"stopping application {app_id}")
+            emr.stop_application(applicationId=app_id)
+            for _ in range(30):
+                state = emr.get_application(applicationId=app_id)["application"]["state"]
+                if state in {"STOPPED", "CREATED", "TERMINATED"}:
+                    break
+                time.sleep(5)
+    except ClientError as e:
+        failed(f"stop application {app_id}", e)
+
+    try:
+        note(f"deleting application {app_id}")
+        emr.delete_application(applicationId=app_id)
+    except ClientError as e:
+        failed(f"delete application {app_id}", e)
+
+
+def drop_glue_databases() -> None:
+    """Delete Glue databases this run created (prefix-scoped, run-agnostic)."""
+    glue = boto3.client("glue", region_name=REGION)
+    try:
+        paginator = glue.get_paginator("get_databases")
+        names = [
+            db["Name"]
+            for page in paginator.paginate()
+            for db in page.get("DatabaseList", [])
+            if db["Name"].startswith(f"{RESOURCE_PREFIX}_")
+        ]
+    except ClientError as e:
+        failed("list glue databases", e)
+        return
+
+    for name in names:
+        try:
+            # Deleting the database drops its tables; the metadata in S3 is
+            # removed by the prefix delete below.
+            glue.delete_database(Name=name)
+            note(f"deleted glue database {name}")
+        except ClientError as e:
+            failed(f"delete glue database {name}", e)
+
+
+def drop_s3tables_namespaces() -> None:
+    if not TABLE_BUCKET_ARN:
+        note("no table bucket configured; skipping S3 Tables cleanup")
+        return
+    s3t = boto3.client("s3tables", region_name=REGION)
+    try:
+        namespaces = [
+            ns
+            for page in s3t.get_paginator("list_namespaces").paginate(tableBucketARN=TABLE_BUCKET_ARN)
+            for ns in page.get("namespaces", [])
+        ]
+    except ClientError as e:
+        failed("list s3tables namespaces", e)
+        return
+
+    for ns in namespaces:
+        names = ns.get("namespace", [])
+        name = names[0] if names else ""
+        if not name.startswith(f"{RESOURCE_PREFIX}_"):
+            continue
+        try:
+            tables = [
+                t["name"]
+                for page in s3t.get_paginator("list_tables").paginate(
+                    tableBucketARN=TABLE_BUCKET_ARN, namespace=name)
+                for t in page.get("tables", [])
+            ]
+            for table in tables:
+                s3t.delete_table(tableBucketARN=TABLE_BUCKET_ARN, namespace=name, name=table)
+                note(f"deleted s3 table {name}.{table}")
+            s3t.delete_namespace(tableBucketARN=TABLE_BUCKET_ARN, namespace=name)
+            note(f"deleted s3tables namespace {name}")
+        except ClientError as e:
+            failed(f"delete s3tables namespace {name}", e)
+
+
+def delete_s3_prefixes() -> None:
+    if not (DATA_BUCKET and RUN_TAG):
+        note("no data bucket or run tag; skipping S3 cleanup")
+        return
+    s3 = boto3.client("s3", region_name=REGION)
+    # reports/ is intentionally left behind; lifecycle expires it.
+    for kind in ("warehouse", "logs", "scripts"):
+        prefix = f"{ENGINE}/{kind}/{RUN_TAG}/"
+        deleted = 0
+        try:
+            pages = s3.get_paginator("list_objects_v2").paginate(Bucket=DATA_BUCKET, Prefix=prefix)
+            batch: list[dict] = []
+            for page in pages:
+                for obj in page.get("Contents", []):
+                    batch.append({"Key": obj["Key"]})
+                    if len(batch) == 1000:
+                        s3.delete_objects(Bucket=DATA_BUCKET, Delete={"Objects": batch})
+                        deleted += len(batch)
+                        batch = []
+            if batch:
+                s3.delete_objects(Bucket=DATA_BUCKET, Delete={"Objects": batch})
+                deleted += len(batch)
+            note(f"deleted {deleted} objects under s3://{DATA_BUCKET}/{prefix}")
+        except ClientError as e:
+            failed(f"delete s3://{DATA_BUCKET}/{prefix}", e)
+
+
+def main() -> int:
+    note(f"run={RUN_TAG or '(unset)'} engine={ENGINE} region={REGION}")
+    kill_emr(application_id())
+    drop_glue_databases()
+    drop_s3tables_namespaces()
+    delete_s3_prefixes()
+
+    if problems:
+        print("\n[teardown] the following could not be cleaned and may still bill:")
+        for p in problems:
+            print(f"  - {p}")
+        print("[teardown] check the EMR Serverless console and the S3 Tables bucket by hand")
+    else:
+        note("all billable resources removed")
+    # Never fail the workflow: a teardown error must not mask the test report.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/iceberg_feature_tests.py
+++ b/tests/iceberg_feature_tests.py
@@ -55,6 +55,27 @@ ICEBERG_JAR = os.environ.get(
     f"iceberg-spark-runtime-{SPARK_VERSION_SHORT}_2.13-{ICEBERG_VERSION}.jar",
 )
 
+# ---------------------------------------------------------------------------
+# Platform targeting. By default this suite measures OSS Spark and compares
+# against the spark cells. A managed platform (EMR Serverless, Glue, ...) reuses
+# the same tests by pointing these at its own catalog and matrix cells.
+# ---------------------------------------------------------------------------
+# Which matrix cells to compare against.
+MATRIX_PLATFORM_ID = os.environ.get("MATRIX_PLATFORM_ID", "spark")
+MATRIX_DATA_PATH = os.environ.get(
+    "MATRIX_DATA_PATH", "src/data/platforms/oss/spark/spark.json"
+)
+# Free-text label for the runtime under test, recorded in the report so a cell
+# that changes later is attributable (e.g. "emr-8.0.0 / s3buckets").
+PLATFORM_LABEL = os.environ.get("PLATFORM_LABEL", "")
+# When set, the primary catalog is built from a catalog-impl rather than REST or
+# Hadoop, and spark-submit owns the jars and the master.
+CATALOG_IMPL = os.environ.get("ICEBERG_CATALOG_IMPL", "")
+CATALOG_WAREHOUSE = os.environ.get("ICEBERG_CATALOG_WAREHOUSE", "")
+# Namespace/database prefix. Managed catalogs are usually IAM-scoped to a name
+# prefix, so this has to be overridable.
+NS_PREFIX = os.environ.get("MATRIX_NS_PREFIX", "ns_")
+
 # REST catalog configuration. An Iceberg REST catalog is the default: the suite
 # targets DEFAULT_REST_URI unless ICEBERG_REST_URI says otherwise. Setting
 # ICEBERG_REST_URI to an empty string opts out and uses the Hadoop catalog.
@@ -138,8 +159,13 @@ def _unique(prefix: str = "t") -> str:
 
 
 def _ns() -> str:
-    """Return a unique namespace (database) name."""
-    return f"ns_{uuid.uuid4().hex[:8]}"
+    """Return a unique namespace (database) name.
+
+    Prefixed with MATRIX_NS_PREFIX so runs against an IAM-scoped catalog (for
+    example Glue, where the CI role is limited to a name prefix) create objects
+    the role is actually allowed to touch.
+    """
+    return f"{NS_PREFIX}{uuid.uuid4().hex[:8]}"
 
 
 def _fmt(version: str) -> str:
@@ -207,10 +233,14 @@ def get_spark():
         jar_coord = None
         print(f"[INFO] Using JARs: {', '.join(jar_paths)}")
 
+    builder = SparkSession.builder.appName("IcebergFeatureTests")
+    if not CATALOG_IMPL:
+        # Local runs need an explicit master. Under spark-submit on a managed
+        # platform the runtime supplies it, and forcing local[*] there would
+        # quietly run the whole job inside the driver container.
+        builder = builder.master("local[*]")
     builder = (
-        SparkSession.builder
-        .appName("IcebergFeatureTests")
-        .master("local[*]")
+        builder
         .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
         .config("spark.sql.defaultCatalog", "local")
         .config("spark.sql.adaptive.enabled", "false")
@@ -229,7 +259,15 @@ def get_spark():
         .config("spark.sql.catalog.hadoop_local.warehouse", WAREHOUSE_URI)
     )
 
-    if REST_URI:
+    if CATALOG_IMPL:
+        print(f"[INFO] Primary catalog: {CATALOG_IMPL} (warehouse {CATALOG_WAREHOUSE})")
+        builder = (
+            builder
+            .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.local.catalog-impl", CATALOG_IMPL)
+            .config("spark.sql.catalog.local.warehouse", CATALOG_WAREHOUSE)
+        )
+    elif REST_URI:
         print(f"[INFO] Primary catalog: REST at {REST_URI} (warehouse {REST_WAREHOUSE})")
         builder = (
             builder
@@ -1432,20 +1470,20 @@ ALL_TESTS = [
 # ---------------------------------------------------------------------------
 
 def load_spark_json_support() -> dict:
-    """Load the JSON support levels for Spark from the nested matrix data.
+    """Load the matrix support levels for the platform under test.
 
     Returns a dict keyed by (feature_id, version) -> level. Reads the nested
-    per-engine file src/data/platforms/oss/spark/spark.json.
+    per-engine file at MATRIX_DATA_PATH and keeps only the keys belonging to
+    MATRIX_PLATFORM_ID, so the same suite can be compared against oss/spark or
+    against a managed platform such as aws/s3buckets/emr.
     """
-    spark_path = os.path.join(
-        REPO_ROOT, "src", "data", "platforms", "oss", "spark", "spark.json"
-    )
-    with open(spark_path) as f:
+    path = os.path.join(REPO_ROOT, *MATRIX_DATA_PATH.split("/"))
+    with open(path) as f:
         data = json.load(f)
     result = {}
     for key, val in data.get("support", {}).items():
         parts = key.split(":")
-        if len(parts) == 3 and parts[0] == "spark":
+        if len(parts) == 3 and parts[0] == MATRIX_PLATFORM_ID:
             feature_id = parts[1]
             version = parts[2]
             result[(feature_id, version)] = val.get("level", "unknown")
@@ -1536,7 +1574,13 @@ def generate_report(results: list[TestResult]) -> dict:
         "timestamp": datetime.utcnow().isoformat() + "Z",
         "spark_version": spark_version,
         "iceberg_version": ICEBERG_VERSION,
-        "catalog_mode": f"REST ({REST_URI})" if REST_URI else "Hadoop (local filesystem)",
+        "platform": MATRIX_PLATFORM_ID,
+        "platform_label": PLATFORM_LABEL,
+        "catalog_mode": (
+            f"{CATALOG_IMPL} ({CATALOG_WAREHOUSE})" if CATALOG_IMPL
+            else f"REST ({REST_URI})" if REST_URI
+            else "Hadoop (local filesystem)"
+        ),
         "versions_tested": VERSIONS,
         "coverage": compute_coverage(results),
         "tests": tests_output,
@@ -1561,6 +1605,8 @@ def generate_markdown(report: dict) -> str:
     lines.append(f"- **Spark Version:** {report['spark_version']}")
     lines.append(f"- **Iceberg Version:** {report['iceberg_version']}")
     lines.append(f"- **Catalog:** {report.get('catalog_mode', 'unknown')}")
+    if report.get("platform_label"):
+        lines.append(f"- **Platform:** {report['platform_label']}")
     lines.append(f"- **Format Versions Tested:** {', '.join(report.get('versions_tested', []))}")
     lines.append("")
 
@@ -1639,7 +1685,11 @@ def main():
     print(f"Warehouse: {WAREHOUSE_DIR}")
     print(f"Repo root: {REPO_ROOT}")
     print(f"Iceberg version: {ICEBERG_VERSION}")
-    print(f"Catalog: {'REST at ' + REST_URI if REST_URI else 'Hadoop (local filesystem)'}")
+    if CATALOG_IMPL:
+        print(f"Catalog: {CATALOG_IMPL} (warehouse {CATALOG_WAREHOUSE})")
+    else:
+        print(f"Catalog: {'REST at ' + REST_URI if REST_URI else 'Hadoop (local filesystem)'}")
+    print(f"Matrix target: {MATRIX_PLATFORM_ID} from {MATRIX_DATA_PATH}")
     print(f"Versions under test: {', '.join(VERSIONS)}")
     print()
 


### PR DESCRIPTION
Run the existing Spark feature suite against managed AWS engines instead of writing a second corpus. EMR Serverless ships Iceberg in the image, so the same 70 checks that measure OSS Spark now measure EMR by swapping the catalog: Glue over an S3 bucket for the s3buckets mode, S3 Tables for the s3tables mode. One dispatch covers the whole platform and produces reports in the same shape the OSS engines emit.

Parameterise the Spark suite so it can target any platform:

- MATRIX_PLATFORM_ID and MATRIX_DATA_PATH choose which matrix cells to compare against, defaulting to the oss/spark ones, so the comparison and discrepancy reporting work unchanged for aws-emr.
- ICEBERG_CATALOG_IMPL builds the primary catalog from a catalog-impl instead of REST or Hadoop, and leaves spark.jars alone because spark-submit owns it.
- MATRIX_NS_PREFIX prefixes generated namespaces. This is required, not cosmetic: the IAM policy is scoped to icebergmatrix*, and the previous ns_ names would have been denied on every Glue call.
- The suite no longer forces master=local[*] when running on a platform, which would have quietly run the whole job inside the driver container.

The AWS side is three pieces. run_emr_serverless.py creates an ephemeral application with no pre-initialized capacity (zero idle cost), submits one job per mode, and downloads the reports. emr_entrypoint.py runs inside the job: it pulls a bundle of the suite plus the matrix data from S3, points the suite at the right catalog, and uploads the report back. teardown.py removes everything billable and never raises, since a cleanup error must not mask the report.

Everything is laid out per engine in the bucket -- emr/scripts, emr/warehouse, emr/logs, emr/reports -- so Athena and Glue slot in alongside later. The workflow already exposes them as choices and fails fast until implemented.

The workflow is dispatch-only with an aws-live environment gate and OIDC; there is no pull_request trigger and no stored AWS keys. Lifecycle rules cover the new per-engine prefixes, including aborting incomplete multipart uploads, which cancelled Spark jobs leave behind and which bill invisibly.

Verified locally: the suite loads all 70 aws-emr cells from the s3buckets file, generates icebergmatrix_ namespaces, and the OSS Spark path still resolves the spark cells with master=local[*] and passes table-creation. The AWS side has not been executed yet; the S3 Tables catalog-impl in particular is unverified against emr-8.0.0 and is overridable via S3TABLES_CATALOG_IMPL.