### PR TITLE
ci(aws): Set up Node 24 in the platform test job

### DIFF
--- a/.github/workflows/aws-platform-tests.yml
+++ b/.github/workflows/aws-platform-tests.yml
@@ -70,6 +70,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:


### PR DESCRIPTION
Match the other workflows: Node 20 is deprecated on GitHub Actions runners, so every job in this repo pins Node 24 explicitly.