### PR TITLE
test(flink): Verify Iceberg 1.11 on Flink 2.3 in Docker, correct matrix data

### DIFF
--- a/.github/workflows/flink-tests.yml
+++ b/.github/workflows/flink-tests.yml
@@ -10,19 +10,20 @@ permissions:
   pull-requests: write
 
 env:
-  # Flink 2.3.0 engine. Iceberg has not released a Flink 2.2/2.3 runtime yet, so
-  # we use the latest published one (iceberg-flink-runtime-2.1), which is
-  # verified to work against the 2.3 engine. FLINK_MAJOR is the runtime's Flink
-  # minor, which can differ from the engine version.
+  # Flink 2.3.0 engine, the latest Flink release. Iceberg has not released a
+  # Flink 2.2/2.3 runtime yet, so we use the latest published one
+  # (iceberg-flink-runtime-2.1) against the 2.3 engine. ICEBERG_FLINK_MAJOR is
+  # the runtime's Flink minor and intentionally differs from the engine version.
   FLINK_VERSION: "2.3.0"
-  FLINK_MAJOR: "2.1"
+  ICEBERG_FLINK_MAJOR: "2.1"
   ICEBERG_VERSION: "1.11.0"
-  HADOOP_UBER_VERSION: "2.8.3-10.0"
 
 jobs:
   flink-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The suite runs every feature against both format versions, each in its own
+    # SQL client session, so it is dominated by session startup cost.
+    timeout-minutes: 75
 
     steps:
       - name: Checkout repository
@@ -47,96 +48,31 @@ jobs:
       - name: Start Lakekeeper REST catalog + MinIO
         run: ./tests/docker/start-lakekeeper.sh
 
-      - name: Download and setup Flink
-        run: |
-          set -euo pipefail
-          FLINK_DIST="flink-${FLINK_VERSION}-bin-scala_2.12.tgz"
-          REL_PATH="flink/flink-${FLINK_VERSION}/${FLINK_DIST}"
-          DEST="${RUNNER_TEMP}/${FLINK_DIST}"
-
-          # archive.apache.org is a single throttled origin and the dist is
-          # ~590 MB: measured side by side, the CDN sustained ~8 MB/s while the
-          # archive stalled at effectively 0. The CDN only carries current
-          # releases though, and closer.lua picks a nearby mirror, so try the
-          # fast sources first and keep the archive as the fallback that always
-          # has the version (including after it ages off the CDN).
-          download() {
-            for url in \
-              "https://dlcdn.apache.org/${REL_PATH}" \
-              "https://www.apache.org/dyn/closer.lua/${REL_PATH}?action=download" \
-              "https://archive.apache.org/dist/${REL_PATH}"
-            do
-              echo "Trying ${url}"
-              if curl -fsSL --retry 3 --retry-connrefused --connect-timeout 15 \
-                   "${url}" -o "${DEST}"; then
-                echo "Downloaded Flink ${FLINK_VERSION} from ${url}"
-                return 0
-              fi
-              rm -f "${DEST}"
-            done
-            echo "All Apache sources failed for ${REL_PATH}" >&2
-            return 1
-          }
-          download
-
-          # Mirrors are third parties, so verify against a checksum published by
-          # the ASF itself before unpacking.
-          curl -fsSL --retry 3 "https://downloads.apache.org/${REL_PATH}.sha512" \
-               -o "${DEST}.sha512" \
-            || curl -fsSL --retry 3 "https://archive.apache.org/dist/${REL_PATH}.sha512" \
-               -o "${DEST}.sha512"
-          (cd "${RUNNER_TEMP}" && sha512sum -c "${FLINK_DIST}.sha512")
-
-          tar -xzf "${DEST}" -C "${RUNNER_TEMP}"
-          echo "FLINK_HOME=${RUNNER_TEMP}/flink-${FLINK_VERSION}" >> $GITHUB_ENV
-
-      - name: Add Iceberg + AWS + Hadoop jars to Flink lib
-        run: |
-          FLINK_HOME="${RUNNER_TEMP}/flink-${FLINK_VERSION}"
-          BASE="https://repo1.maven.org/maven2/org/apache"
-          # Iceberg Flink runtime (2.1 is the latest published), plus the AWS bundle
-          # that provides S3FileIO so Iceberg reads/writes data files on S3 (MinIO).
-          curl -fsSL "${BASE}/iceberg/iceberg-flink-runtime-${FLINK_MAJOR}/${ICEBERG_VERSION}/iceberg-flink-runtime-${FLINK_MAJOR}-${ICEBERG_VERSION}.jar" \
-            -o "${FLINK_HOME}/lib/iceberg-flink-runtime-${FLINK_MAJOR}-${ICEBERG_VERSION}.jar"
-          curl -fsSL "${BASE}/iceberg/iceberg-aws-bundle/${ICEBERG_VERSION}/iceberg-aws-bundle-${ICEBERG_VERSION}.jar" \
-            -o "${FLINK_HOME}/lib/iceberg-aws-bundle-${ICEBERG_VERSION}.jar"
-          # Iceberg's Flink catalog loader instantiates org.apache.hadoop.conf.Configuration
-          # regardless of catalog type, so Hadoop classes are required on the classpath.
-          curl -fsSL "${BASE}/flink/flink-shaded-hadoop-2-uber/${HADOOP_UBER_VERSION}/flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar" \
-            -o "${FLINK_HOME}/lib/flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar"
-
-      - name: Start Flink cluster
-        run: |
-          echo "Starting Flink standalone cluster..."
-          "${FLINK_HOME}/bin/start-cluster.sh"
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:8081/overview > /dev/null 2>&1; then
-              echo "Flink cluster is ready"
-              break
-            fi
-            echo "Waiting for Flink cluster... ($i/30)"
-            sleep 2
-          done
+      # Flink runs in Docker rather than as a runner-local tarball so that the
+      # exact same cluster, jars and classpath are reproducible locally.
+      - name: Start Dockerized Flink cluster with the Iceberg runtime
+        run: ./tests/docker/start-flink.sh
 
       - name: Run Flink Iceberg feature tests
         env:
-          ICEBERG_REST_URI: http://127.0.0.1:8181/catalog
+          FLINK_MODE: docker
           ICEBERG_REST_WAREHOUSE: demo
-          ICEBERG_S3_ENDPOINT: http://127.0.0.1:9000
           ICEBERG_S3_KEY_ID: minio
           ICEBERG_S3_SECRET: minio12345
         run: |
           export REPO_ROOT="${GITHUB_WORKSPACE}"
           export REPORT_DIR="${GITHUB_WORKSPACE}/test-reports"
-          export FLINK_VERSION="${FLINK_VERSION}"
           export FLINK_ICEBERG_VERSION="${ICEBERG_VERSION}"
           python tests/flink_feature_tests.py
         continue-on-error: true
 
+      - name: Dump Flink cluster logs on failure
+        if: failure()
+        run: docker compose -f tests/docker/docker-compose.flink.yml logs --tail 200 || true
+
       - name: Stop Flink cluster
         if: always()
-        run: |
-          "${FLINK_HOME}/bin/stop-cluster.sh" || true
+        run: ./tests/docker/stop-flink.sh
 
       - name: Tear down Lakekeeper REST catalog
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ tests/flink-venv/
 __pycache__/
 tests/iceberg-flink-runtime-*.jar
 test-reports/
+# SQL scripts the Flink harness hands to the Dockerized cluster via bind mount
+tests/docker/flink-work/

--- a/src/data/platforms/oss/flink/flink.json
+++ b/src/data/platforms/oss/flink/flink.json
@@ -263,15 +263,20 @@
     },
     "flink:time-travel:v2": {
       "level": "full",
-      "notes": "Flink supports time travel via snapshot-id and as-of-timestamp read options in batch mode, plus branch and tag reads via SQL hints",
+      "notes": "Time travel via SQL hints: snapshot-id and as-of-timestamp for point-in-time reads, branch and tag for ref reads, and start/end-snapshot-id or start/end-tag for incremental scans between two table states. Snapshot ids and refs are discoverable through the $snapshots and $refs metadata tables.",
       "caveats": [
         "Uses SQL hint syntax (/*+ OPTIONS('snapshot-id'='...') */) rather than native SQL time travel syntax"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/#reading-branches-and-tags-with-sql"
+      "links": [
+        {
+          "label": "Flink queries",
+          "url": "https://iceberg.apache.org/docs/latest/flink-queries/"
+        }
+      ]
     },
     "flink:time-travel:v3": {
       "level": "full",
-      "notes": "Snapshot ids are readable from the $snapshots metadata table, and reads at a specific snapshot, timestamp, branch or tag use SQL hints (snapshot-id, as-of-timestamp, branch, tag).",
+      "notes": "Time travel via SQL hints: snapshot-id and as-of-timestamp for point-in-time reads, branch and tag for ref reads, and start/end-snapshot-id or start/end-tag for incremental scans between two table states. Snapshot ids and refs are discoverable through the $snapshots and $refs metadata tables.",
       "caveats": [
         "Uses SQL hint syntax (/*+ OPTIONS('snapshot-id'='...') */) rather than native SQL time travel syntax"
       ],
@@ -316,19 +321,29 @@
     },
     "flink:branching-tagging:v2": {
       "level": "partial",
-      "notes": "Flink can write to branches via FlinkSink.toBranch() and read from branches/tags via SQL hints, including incremental scan between tags. Cannot create or manage branches/tags via DDL",
+      "notes": "Flink reads branches and tags via SQL hints (branch, tag), supports tag-to-tag incremental scans (start-tag/end-tag), and can write to branches via FlinkSink.toBranch() in the Java API. It cannot create or manage refs: there is no branch or tag DDL, so refs must be created by another engine or the catalog.",
       "caveats": [
-        "Cannot create or manage branches/tags; read and write to existing branches/tags only"
+        "Cannot create or manage branches/tags from Flink; read via hints and write via the Java API only"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/#reading-branches-and-tags-with-sql"
+      "links": [
+        {
+          "label": "Flink queries",
+          "url": "https://iceberg.apache.org/docs/latest/flink-queries/"
+        }
+      ]
     },
     "flink:branching-tagging:v3": {
       "level": "partial",
-      "notes": "Flink can write to branches via FlinkSink.toBranch() and read from branches/tags via SQL hints for V3 tables. Cannot create or manage branches/tags via DDL",
+      "notes": "Flink reads branches and tags via SQL hints (branch, tag), supports tag-to-tag incremental scans (start-tag/end-tag), and can write to branches via FlinkSink.toBranch() in the Java API. It cannot create or manage refs: there is no branch or tag DDL, so refs must be created by another engine or the catalog.",
       "caveats": [
-        "Cannot create or manage branches/tags; read and write to existing branches/tags only"
+        "Cannot create or manage branches/tags from Flink; read via hints and write via the Java API only"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/#reading-branches-and-tags-with-sql"
+      "links": [
+        {
+          "label": "Flink queries",
+          "url": "https://iceberg.apache.org/docs/latest/flink-queries/"
+        }
+      ]
     },
     "flink:read-support:v2": {
       "level": "full",
@@ -550,9 +565,16 @@
     },
     "flink:hadoop-catalog:v2": {
       "level": "full",
-      "notes": "Built-in Hadoop catalog support via catalog-type='hadoop'; ships with Hadoop jars by default",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#hadoop-catalog"
+      "notes": "Full support via catalog-type='hadoop' on a filesystem warehouse. Flink does not ship Hadoop jars; Hadoop 3.3+ client jars must be added to the classpath, since Iceberg 1.11's Hadoop file IO calls FileSystem.openFile(), absent from older Hadoop 2 jars.",
+      "caveats": [
+        "Needs Hadoop 3.3+ jars on the Flink classpath"
+      ],
+      "links": [
+        {
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        }
+      ]
     },
     "flink:hadoop-catalog:v3": {
       "level": "full",

--- a/src/data/platforms/oss/flink/flink.json
+++ b/src/data/platforms/oss/flink/flink.json
@@ -12,9 +12,9 @@
   "support": {
     "flink:position-deletes:v2": {
       "level": "full",
-      "notes": "Flink reads position deletes, and the Iceberg Flink writer emits them for rows superseded within a single writer task. They cannot be produced on demand from Flink SQL, which has no DELETE statement: an upsert writes equality delete files (observed as content=2 Parquet files), so this harness could not exercise the position-delete write path directly.",
+      "notes": "Verified: when an upsert sees the same key twice in one batch, the superseded row is deleted by position and Flink writes a Parquet position delete file (content=1), which the reader merges correctly. Flink SQL has no DELETE statement, so position deletes cannot be requested directly -- they fall out of the upsert write path.",
       "caveats": [
-        "Cannot be requested from Flink SQL; upsert emits equality deletes instead"
+        "Cannot be requested explicitly from Flink SQL; produced by the upsert writer"
       ],
       "links": [
         {
@@ -25,14 +25,15 @@
     },
     "flink:position-deletes:v3": {
       "level": "full",
-      "notes": "Flink reads position deletes, and the Iceberg Flink writer emits them for rows superseded within a single writer task. They cannot be produced on demand from Flink SQL, which has no DELETE statement: an upsert writes equality delete files (observed as content=2 Parquet files), so this harness could not exercise the position-delete write path directly.",
+      "notes": "Verified on V3: the same-batch upsert path writes the position delete as a puffin deletion vector (content=1, file_format=PUFFIN) rather than a Parquet delete file, and the reader merges it correctly.",
       "caveats": [
-        "Cannot be requested from Flink SQL; upsert emits equality deletes instead"
+        "On V3 these are written as deletion vectors, per the spec",
+        "Cannot be requested explicitly from Flink SQL; produced by the upsert writer"
       ],
       "links": [
         {
-          "label": "Flink writes",
-          "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+          "label": "Apache Iceberg 1.11.0 release notes",
+          "url": "https://iceberg.apache.org/blog/apache-iceberg-1.11.0-release/"
         }
       ]
     },
@@ -61,16 +62,34 @@
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
     },
     "flink:copy-on-write:v2": {
-      "level": "full",
-      "notes": "Copy-on-write supported via INSERT INTO and INSERT OVERWRITE",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into"
+      "level": "partial",
+      "notes": "Only whole-table or whole-partition overwrite is reachable: INSERT OVERWRITE was verified to rewrite the data files with no delete files. Copy-on-write proper means rewriting files to satisfy a row-level UPDATE or DELETE, and Flink SQL has neither, so write.delete.mode/write.update.mode='copy-on-write' has nothing to act on.",
+      "caveats": [
+        "No row-level UPDATE/DELETE in Flink SQL, so the copy-on-write write modes are inert",
+        "INSERT OVERWRITE is batch-only"
+      ],
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into",
+      "links": [
+        {
+          "label": "Flink writes",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+        }
+      ]
     },
     "flink:copy-on-write:v3": {
-      "level": "full",
-      "notes": "Copy-on-write supported via INSERT INTO and INSERT OVERWRITE with V3 format",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into"
+      "level": "partial",
+      "notes": "Only whole-table or whole-partition overwrite is reachable: INSERT OVERWRITE was verified to rewrite the data files with no delete files. Copy-on-write proper means rewriting files to satisfy a row-level UPDATE or DELETE, and Flink SQL has neither, so write.delete.mode/write.update.mode='copy-on-write' has nothing to act on.",
+      "caveats": [
+        "No row-level UPDATE/DELETE in Flink SQL, so the copy-on-write write modes are inert",
+        "INSERT OVERWRITE is batch-only"
+      ],
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into",
+      "links": [
+        {
+          "label": "Flink writes",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+        }
+      ]
     },
     "flink:schema-evolution:v2": {
       "level": "full",
@@ -158,9 +177,10 @@
     },
     "flink:partition-evolution:v2": {
       "level": "partial",
-      "notes": "Not expressible in Flink SQL: ALTER TABLE ... ADD PARTITION FIELD is a parser error. Partition specs can be evolved at runtime by the Dynamic Sink, which is a Java API (Iceberg 1.10+), so evolution is available to Flink jobs but not to SQL users.",
+      "notes": "Flink cannot initiate partition evolution -- there is no SQL syntax for it, and ALTER TABLE ADD PARTITION FIELD is a Spark SQL extension that Flink's parser rejects. It does honour an evolution performed elsewhere: verified by adding day(ts) as the default spec through the catalog, after which a Flink write landed in the new spec while the pre-existing data file stayed on the old one, and reads spanned both. The Dynamic Sink can also evolve specs at runtime, but only through the Java API.",
       "caveats": [
-        "No SQL syntax for partition evolution; requires the Dynamic Sink Java API"
+        "No SQL syntax to evolve a spec; evolution must be initiated by another engine or the Java Dynamic Sink",
+        "Existing data files keep their original spec; only new writes use the new one"
       ],
       "links": [
         {
@@ -171,9 +191,10 @@
     },
     "flink:partition-evolution:v3": {
       "level": "partial",
-      "notes": "Not expressible in Flink SQL: ALTER TABLE ... ADD PARTITION FIELD is a parser error. Partition specs can be evolved at runtime by the Dynamic Sink, which is a Java API (Iceberg 1.10+), so evolution is available to Flink jobs but not to SQL users.",
+      "notes": "Flink cannot initiate partition evolution -- there is no SQL syntax for it, and ALTER TABLE ADD PARTITION FIELD is a Spark SQL extension that Flink's parser rejects. It does honour an evolution performed elsewhere: verified by adding day(ts) as the default spec through the catalog, after which a Flink write landed in the new spec while the pre-existing data file stayed on the old one, and reads spanned both. The Dynamic Sink can also evolve specs at runtime, but only through the Java API.",
       "caveats": [
-        "No SQL syntax for partition evolution; requires the Dynamic Sink Java API"
+        "No SQL syntax to evolve a spec; evolution must be initiated by another engine or the Java Dynamic Sink",
+        "Existing data files keep their original spec; only new writes use the new one"
       ],
       "links": [
         {
@@ -580,9 +601,10 @@
     },
     "flink:lineage:v3": {
       "level": "partial",
-      "notes": "Iceberg 1.11 added row lineage readers to the Flink module and preserves lineage through RewriteDataFiles compaction, but the lineage columns are not projectable from Flink SQL: selecting _row_id fails with \"Column '_row_id' not found in any table\" on a V3 table. Snapshot sequence numbers remain readable from metadata tables.",
+      "notes": "Flink maintains V3 row lineage when it writes: after a 3-row insert the table metadata carries next-row-id=3 and the snapshot reports first-row-id=0 with added-rows=3, and Iceberg 1.11 preserves lineage through RewriteDataFiles compaction. None of it is reachable from Flink SQL, though -- selecting _row_id fails, metadata (computed) columns are rejected outright, and $snapshots exposes no lineage column.",
       "caveats": [
-        "_row_id and _last_updated_sequence_number cannot be selected in Flink SQL"
+        "Row lineage is written but cannot be read from Flink SQL",
+        "_row_id and _last_updated_sequence_number are not projectable; computed/metadata columns are unsupported"
       ],
       "links": [
         {

--- a/src/data/platforms/oss/flink/flink.json
+++ b/src/data/platforms/oss/flink/flink.json
@@ -12,15 +12,29 @@
   "support": {
     "flink:position-deletes:v2": {
       "level": "full",
-      "notes": "Flink supports reading and writing position deletes in both batch and streaming modes",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/"
+      "notes": "Flink reads position deletes, and the Iceberg Flink writer emits them for rows superseded within a single writer task. They cannot be produced on demand from Flink SQL, which has no DELETE statement: an upsert writes equality delete files (observed as content=2 Parquet files), so this harness could not exercise the position-delete write path directly.",
+      "caveats": [
+        "Cannot be requested from Flink SQL; upsert emits equality deletes instead"
+      ],
+      "links": [
+        {
+          "label": "Flink writes",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+        }
+      ]
     },
     "flink:position-deletes:v3": {
       "level": "full",
-      "notes": "Position deletes supported via Iceberg library V3 support (iceberg-flink-runtime 1.10.x+)",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/"
+      "notes": "Flink reads position deletes, and the Iceberg Flink writer emits them for rows superseded within a single writer task. They cannot be produced on demand from Flink SQL, which has no DELETE statement: an upsert writes equality delete files (observed as content=2 Parquet files), so this harness could not exercise the position-delete write path directly.",
+      "caveats": [
+        "Cannot be requested from Flink SQL; upsert emits equality deletes instead"
+      ],
+      "links": [
+        {
+          "label": "Flink writes",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+        }
+      ]
     },
     "flink:equality-deletes:v2": {
       "level": "full",
@@ -59,20 +73,28 @@
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into"
     },
     "flink:schema-evolution:v2": {
-      "level": "partial",
-      "notes": "Flink can read tables with evolved schemas, but ALTER TABLE only supports changing table properties — column and partition changes are not supported via Flink DDL",
-      "caveats": [
-        "ALTER TABLE only supports changing table properties; column additions, renames, drops, and reordering not supported via Flink SQL"
-      ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#alter-table"
+      "level": "full",
+      "notes": "Verified on Flink 2.3 + Iceberg 1.11: ALTER TABLE ADD, RENAME, DROP and MODIFY (including repositioning with AFTER) all succeed via Flink SQL DDL, and rows written before the change still read back correctly.",
+      "caveats": [],
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#alter-table",
+      "links": [
+        {
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        }
+      ]
     },
     "flink:schema-evolution:v3": {
-      "level": "partial",
-      "notes": "Flink can read V3 tables with evolved schemas, but ALTER TABLE only supports changing table properties — column and partition changes are not supported via Flink DDL",
-      "caveats": [
-        "ALTER TABLE only supports changing table properties; column additions, renames, drops, and reordering not supported via Flink SQL"
-      ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#alter-table"
+      "level": "full",
+      "notes": "Verified on Flink 2.3 + Iceberg 1.11: ALTER TABLE ADD, RENAME, DROP and MODIFY (including repositioning with AFTER) all succeed via Flink SQL DDL, and rows written before the change still read back correctly.",
+      "caveats": [],
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#alter-table",
+      "links": [
+        {
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        }
+      ]
     },
     "flink:column-default-values:v2": {
       "level": "none",
@@ -80,10 +102,16 @@
       "caveats": []
     },
     "flink:column-default-values:v3": {
-      "level": "unknown",
-      "notes": "Column default values are a V3 feature; Flink Iceberg integration has not explicitly documented support",
+      "level": "none",
+      "notes": "Not expressible in Flink SQL: the parser rejects DEFAULT in CREATE TABLE (ParseException on \"DEFAULT\"), so a V3 initial-default/write-default cannot be declared from Flink.",
       "caveats": [
-        "No explicit documentation for Flink support of V3 column default values"
+        "Flink SQL DDL has no column DEFAULT clause"
+      ],
+      "links": [
+        {
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        }
       ]
     },
     "flink:nanosecond-timestamps:v2": {
@@ -104,43 +132,53 @@
     },
     "flink:hidden-partitioning:v2": {
       "level": "partial",
-      "notes": "Flink can read and write to tables with hidden partitions created by other engines, but Flink DDL does not support creating tables with transform-based (hidden) partitioning",
+      "notes": "Flink DDL accepts only plain column names in PARTITIONED BY; a transform such as days(ts) is a parser error, so hidden-partitioned tables must be created by another engine. Flink reads and writes such tables correctly once they exist.",
       "caveats": [
-        "Flink DDL PARTITION BY does not support transform functions (e.g., days(), hours(), bucket()); use Spark or another engine to create hidden-partitioned tables"
-      ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#partitioned-by"
-    },
-    "flink:hidden-partitioning:v3": {
-      "level": "partial",
-      "notes": "Flink can read and write to V3 tables with hidden partitions created by other engines, but Flink DDL does not support creating tables with transform-based (hidden) partitioning",
-      "caveats": [
-        "Flink DDL PARTITION BY does not support transform functions (e.g., days(), hours(), bucket()); use Spark or another engine to create hidden-partitioned tables"
-      ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#partitioned-by"
-    },
-    "flink:partition-evolution:v2": {
-      "level": "partial",
-      "notes": "Partition evolution supported via the Dynamic Sink (Sink V2-based implementation)",
-      "caveats": [
-        "Requires Dynamic Sink (Sink V2-based implementation)"
+        "Flink DDL cannot declare transform (hidden) partitioning; identity columns only"
       ],
       "links": [
         {
-          "label": "Flink Sink V2-based implementation",
-          "url": "https://iceberg.apache.org/docs/nightly/flink-writes/#sink-v2-based-implementation"
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        }
+      ]
+    },
+    "flink:hidden-partitioning:v3": {
+      "level": "partial",
+      "notes": "Flink DDL accepts only plain column names in PARTITIONED BY; a transform such as days(ts) is a parser error, so hidden-partitioned tables must be created by another engine. Flink reads and writes such tables correctly once they exist.",
+      "caveats": [
+        "Flink DDL cannot declare transform (hidden) partitioning; identity columns only"
+      ],
+      "links": [
+        {
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        }
+      ]
+    },
+    "flink:partition-evolution:v2": {
+      "level": "partial",
+      "notes": "Not expressible in Flink SQL: ALTER TABLE ... ADD PARTITION FIELD is a parser error. Partition specs can be evolved at runtime by the Dynamic Sink, which is a Java API (Iceberg 1.10+), so evolution is available to Flink jobs but not to SQL users.",
+      "caveats": [
+        "No SQL syntax for partition evolution; requires the Dynamic Sink Java API"
+      ],
+      "links": [
+        {
+          "label": "Flink Dynamic Iceberg Sink",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#flink-dynamic-iceberg-sink"
         }
       ]
     },
     "flink:partition-evolution:v3": {
       "level": "partial",
-      "notes": "Partition evolution supported via the Dynamic Sink (Sink V2-based implementation) for V3 tables",
+      "notes": "Not expressible in Flink SQL: ALTER TABLE ... ADD PARTITION FIELD is a parser error. Partition specs can be evolved at runtime by the Dynamic Sink, which is a Java API (Iceberg 1.10+), so evolution is available to Flink jobs but not to SQL users.",
       "caveats": [
-        "Requires Dynamic Sink (Sink V2-based implementation)"
+        "No SQL syntax for partition evolution; requires the Dynamic Sink Java API"
       ],
       "links": [
         {
-          "label": "Flink Sink V2-based implementation",
-          "url": "https://iceberg.apache.org/docs/nightly/flink-writes/#sink-v2-based-implementation"
+          "label": "Flink Dynamic Iceberg Sink",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#flink-dynamic-iceberg-sink"
         }
       ]
     },
@@ -151,9 +189,15 @@
     },
     "flink:multi-arg-transforms:v3": {
       "level": "unknown",
-      "notes": "Multi-argument transforms are a V3 feature; Flink Iceberg integration has not explicitly documented support",
+      "notes": "Undeclarable from Flink SQL: PARTITIONED BY accepts only plain column names, so no transform -- single or multi-argument -- can be expressed in Flink DDL. Whether Flink reads tables partitioned this way by another engine is untested.",
       "caveats": [
-        "No explicit documentation for Flink support of V3 multi-argument transforms"
+        "Cannot be declared in Flink DDL; read path untested"
+      ],
+      "links": [
+        {
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        }
       ]
     },
     "flink:time-travel:v2": {
@@ -166,27 +210,46 @@
     },
     "flink:time-travel:v3": {
       "level": "full",
-      "notes": "Time travel supported for V3 tables via snapshot-id, as-of-timestamp, branch, and tag read options",
+      "notes": "Verified on a V3 table: snapshot ids read from the $snapshots metadata table, then SELECT with the snapshot-id hint returned exactly the rows present at that snapshot.",
       "caveats": [
         "Uses SQL hint syntax (/*+ OPTIONS('snapshot-id'='...') */) rather than native SQL time travel syntax"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/#reading-branches-and-tags-with-sql"
+      "links": [
+        {
+          "label": "Flink queries",
+          "url": "https://iceberg.apache.org/docs/latest/flink-queries/"
+        }
+      ]
     },
     "flink:table-maintenance:v2": {
       "level": "partial",
-      "notes": "Flink supports the rewrite files action (compaction) but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests — use Spark for full maintenance",
+      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own job: IcebergSink post-commit tasks are configured from SQL with flink-maintenance.* options (RewriteDataFiles, ExpireSnapshots, DeleteOrphanFiles). The options are accepted, but no rewrite commit was observed from a batch SQL INSERT in this harness. There is no RewriteManifests task in 1.11, and the standalone TableMaintenance API is Java-only.",
       "caveats": [
-        "Only rewrite files action available; expire_snapshots, remove_orphan_files, rewrite_manifests not supported"
+        "Post-commit maintenance is configured from SQL but was not observed to trigger in batch mode",
+        "No rewrite_manifests equivalent in the Flink maintenance API (1.11)",
+        "Requires the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true); SQL lock type accepts only jdbc or zookeeper"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink/"
+      "links": [
+        {
+          "label": "Flink maintenance",
+          "url": "https://iceberg.apache.org/docs/latest/flink-maintenance/"
+        }
+      ]
     },
     "flink:table-maintenance:v3": {
       "level": "partial",
-      "notes": "Flink supports the rewrite files action (compaction) for V3 tables but does not support expire_snapshots, remove_orphan_files, or rewrite_manifests",
+      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own job: IcebergSink post-commit tasks are configured from SQL with flink-maintenance.* options (RewriteDataFiles, ExpireSnapshots, DeleteOrphanFiles). The options are accepted, but no rewrite commit was observed from a batch SQL INSERT in this harness. There is no RewriteManifests task in 1.11, and the standalone TableMaintenance API is Java-only.",
       "caveats": [
-        "Only rewrite files action available; expire_snapshots, remove_orphan_files, rewrite_manifests not supported"
+        "Post-commit maintenance is configured from SQL but was not observed to trigger in batch mode",
+        "No rewrite_manifests equivalent in the Flink maintenance API (1.11)",
+        "Requires the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true); SQL lock type accepts only jdbc or zookeeper"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink/"
+      "links": [
+        {
+          "label": "Flink maintenance",
+          "url": "https://iceberg.apache.org/docs/latest/flink-maintenance/"
+        }
+      ]
     },
     "flink:branching-tagging:v2": {
       "level": "partial",
@@ -234,33 +297,57 @@
     },
     "flink:write-merge-update-delete:v2": {
       "level": "partial",
-      "notes": "Flink supports UPSERT mode via equality deletes (requires V2 format and primary key) but does not support SQL MERGE INTO, UPDATE, or DELETE statements",
+      "notes": "Verified: Flink SQL rejects both DELETE and UPDATE against Iceberg tables (UnsupportedOperationException), and has no MERGE INTO. Upsert mode with equality deletes is the only row-level write path, and it was verified to replace a row by primary key.",
       "caveats": [
-        "No SQL MERGE INTO, UPDATE, or DELETE syntax; uses streaming upsert mode with equality deletes instead",
-        "UPSERT requires V2+ format and a PRIMARY KEY defined on the table"
+        "No SQL MERGE INTO, UPDATE or DELETE; upsert mode via equality deletes instead",
+        "UPSERT requires a PRIMARY KEY NOT ENFORCED and format-version 2 or higher"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+      "links": [
+        {
+          "label": "Flink upsert",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+        }
+      ]
     },
     "flink:write-merge-update-delete:v3": {
       "level": "partial",
-      "notes": "Flink supports UPSERT mode via equality deletes (requires primary key) but does not support SQL MERGE INTO, UPDATE, or DELETE statements",
+      "notes": "Verified: Flink SQL rejects both DELETE and UPDATE against Iceberg tables (UnsupportedOperationException), and has no MERGE INTO. Upsert mode with equality deletes is the only row-level write path, and it was verified to replace a row by primary key.",
       "caveats": [
-        "No SQL MERGE INTO, UPDATE, or DELETE syntax; uses streaming upsert mode with equality deletes instead",
-        "UPSERT requires a PRIMARY KEY defined on the table"
+        "No SQL MERGE INTO, UPDATE or DELETE; upsert mode via equality deletes instead",
+        "UPSERT requires a PRIMARY KEY NOT ENFORCED and format-version 2 or higher"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+      "links": [
+        {
+          "label": "Flink upsert",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+        }
+      ]
     },
     "flink:catalog-integration:v2": {
       "level": "full",
-      "notes": "Supports built-in catalog types: hive, hadoop, rest, glue, jdbc, nessie, plus custom catalog implementations via catalog-impl",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+      "notes": "Verified end to end against a REST catalog, a filesystem Hadoop catalog and a JDBC catalog on Postgres. Flink's catalog-type option accepts only hive, hadoop and rest; every other Iceberg catalog (glue, jdbc, nessie, custom) is reached through catalog-impl, and setting both at once is rejected.",
+      "caveats": [
+        "catalog-type is limited to hive/hadoop/rest; others require catalog-impl"
+      ],
+      "links": [
+        {
+          "label": "Flink catalog configuration",
+          "url": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+        }
+      ]
     },
     "flink:catalog-integration:v3": {
       "level": "full",
-      "notes": "Supports built-in catalog types: hive, hadoop, rest, glue, jdbc, nessie, plus custom catalog implementations via catalog-impl",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+      "notes": "Verified end to end against a REST catalog, a filesystem Hadoop catalog and a JDBC catalog on Postgres. Flink's catalog-type option accepts only hive, hadoop and rest; every other Iceberg catalog (glue, jdbc, nessie, custom) is reached through catalog-impl, and setting both at once is rejected.",
+      "caveats": [
+        "catalog-type is limited to hive/hadoop/rest; others require catalog-impl"
+      ],
+      "links": [
+        {
+          "label": "Flink catalog configuration",
+          "url": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+        }
+      ]
     },
     "flink:hive-metastore:v2": {
       "level": "full",
@@ -276,15 +363,29 @@
     },
     "flink:aws-glue-catalog:v2": {
       "level": "full",
-      "notes": "Built-in AWS Glue Catalog support via catalog-type='glue'",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+      "notes": "Supported via catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog with the iceberg-aws bundle on the classpath. Flink's catalog-type option accepts only hive, hadoop and rest, so Glue is not selectable with catalog-type='glue'. Not exercised here (needs AWS credentials).",
+      "caveats": [
+        "Configured via catalog-impl, not catalog-type"
+      ],
+      "links": [
+        {
+          "label": "Flink catalog configuration",
+          "url": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+        }
+      ]
     },
     "flink:aws-glue-catalog:v3": {
       "level": "full",
-      "notes": "Built-in AWS Glue Catalog support via catalog-type='glue'",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+      "notes": "Supported via catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog with the iceberg-aws bundle on the classpath. Flink's catalog-type option accepts only hive, hadoop and rest, so Glue is not selectable with catalog-type='glue'. Not exercised here (needs AWS credentials).",
+      "caveats": [
+        "Configured via catalog-impl, not catalog-type"
+      ],
+      "links": [
+        {
+          "label": "Flink catalog configuration",
+          "url": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+        }
+      ]
     },
     "flink:rest-catalog:v2": {
       "level": "full",
@@ -300,15 +401,29 @@
     },
     "flink:nessie:v2": {
       "level": "full",
-      "notes": "Built-in Nessie catalog support via catalog-type='nessie'",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+      "notes": "Supported via catalog-impl=org.apache.iceberg.nessie.NessieCatalog. Flink's catalog-type option accepts only hive, hadoop and rest, so Nessie is not selectable with catalog-type='nessie'. Not exercised here (needs a Nessie server).",
+      "caveats": [
+        "Configured via catalog-impl, not catalog-type"
+      ],
+      "links": [
+        {
+          "label": "Flink catalog configuration",
+          "url": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+        }
+      ]
     },
     "flink:nessie:v3": {
       "level": "full",
-      "notes": "Built-in Nessie catalog support via catalog-type='nessie'",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+      "notes": "Supported via catalog-impl=org.apache.iceberg.nessie.NessieCatalog. Flink's catalog-type option accepts only hive, hadoop and rest, so Nessie is not selectable with catalog-type='nessie'. Not exercised here (needs a Nessie server).",
+      "caveats": [
+        "Configured via catalog-impl, not catalog-type"
+      ],
+      "links": [
+        {
+          "label": "Flink catalog configuration",
+          "url": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+        }
+      ]
     },
     "flink:polaris:v2": {
       "level": "full",
@@ -346,21 +461,42 @@
     },
     "flink:hadoop-catalog:v3": {
       "level": "full",
-      "notes": "Built-in Hadoop catalog support via catalog-type='hadoop'",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#hadoop-catalog"
+      "notes": "Verified on a V3 table: create, write, read and drop through catalog-type='hadoop' on a filesystem warehouse. Requires Hadoop 3.3+ client jars -- Iceberg 1.11's Hadoop file IO calls FileSystem.openFile(), which is absent from the older flink-shaded-hadoop-2 uber jar and makes every read fail with NoSuchMethodError.",
+      "caveats": [
+        "Needs Hadoop 3.3+ jars on the Flink classpath"
+      ],
+      "links": [
+        {
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        }
+      ]
     },
     "flink:jdbc-catalog:v2": {
       "level": "full",
-      "notes": "Built-in JDBC catalog support via catalog-type='jdbc'",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+      "notes": "Verified against Postgres: create, write, read and drop through the JDBC catalog. Configured with catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog -- Flink's catalog-type option accepts only hive, hadoop and rest.",
+      "caveats": [
+        "Configured via catalog-impl, not catalog-type"
+      ],
+      "links": [
+        {
+          "label": "Flink catalog configuration",
+          "url": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+        }
+      ]
     },
     "flink:jdbc-catalog:v3": {
       "level": "full",
-      "notes": "Built-in JDBC catalog support via catalog-type='jdbc'",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+      "notes": "Verified against Postgres on a V3 table: create, write, read and drop through the JDBC catalog, configured with catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog.",
+      "caveats": [
+        "Configured via catalog-impl, not catalog-type"
+      ],
+      "links": [
+        {
+          "label": "Flink catalog configuration",
+          "url": "https://iceberg.apache.org/docs/latest/flink-configuration/#catalog-configuration"
+        }
+      ]
     },
     "flink:table-creation:v2": {
       "level": "full",
@@ -385,9 +521,10 @@
     },
     "flink:variant-type:v3": {
       "level": "partial",
-      "notes": "Variant type is supported in Flink 2.1 (Iceberg 1.11.0), enabling semi-structured data ingestion and processing in Flink pipelines. Shredded Variant reads/writes are not yet documented.",
+      "notes": "Verified on Flink 2.3 + Iceberg 1.11: a VARIANT column can be declared on a V3 table and written with PARSE_JSON, and the value reads back non-null. Field extraction is not possible from Flink SQL, which offers only the PARSE_JSON/TRY_PARSE_JSON constructors with no variant accessor and no CAST from VARIANT.",
       "caveats": [
-        "Shredded Variant support is not yet documented for Flink"
+        "No variant field accessor in Flink SQL; values are opaque once stored",
+        "Shredded Variant reads/writes are not observable from Flink SQL"
       ],
       "links": [
         {
@@ -403,8 +540,16 @@
     },
     "flink:shredded-variant:v3": {
       "level": "unknown",
-      "notes": "OSS Flink V3 shredded variant support is not yet documented",
-      "caveats": []
+      "notes": "Not observable from Flink SQL: the Parquet variant-shredding write property is accepted and data round-trips, but no Flink SQL surface or Iceberg metadata table reports whether the writer actually shredded the variant.",
+      "caveats": [
+        "Not observable through Flink SQL or metadata tables"
+      ],
+      "links": [
+        {
+          "label": "Apache Iceberg 1.11.0 release notes",
+          "url": "https://iceberg.apache.org/blog/apache-iceberg-1.11.0-release/"
+        }
+      ]
     },
     "flink:geometry-type:v2": {
       "level": "none",
@@ -412,9 +557,17 @@
       "caveats": []
     },
     "flink:geometry-type:v3": {
-      "level": "unknown",
-      "notes": "OSS Flink V3 geometry type support is not yet documented",
-      "caveats": []
+      "level": "none",
+      "notes": "Blocked by Flink rather than Iceberg: Flink's Calcite-based planner keeps GEOMETRY behind Calcite's spatial extensions, which are enabled by a JDBC connect-string property (fun=spatial) that Flink exposes no configuration for. CREATE TABLE with a GEOMETRY column fails with \"Geo-spatial extensions and the GEOMETRY data type are not enabled\".",
+      "caveats": [
+        "Flink's planner gates the GEOMETRY type; not a limitation of the Iceberg Flink module"
+      ],
+      "links": [
+        {
+          "label": "Apache Calcite spatial",
+          "url": "https://calcite.apache.org/docs/spatial.html"
+        }
+      ]
     },
     "flink:lineage:v2": {
       "level": "none",
@@ -422,9 +575,11 @@
       "caveats": []
     },
     "flink:lineage:v3": {
-      "level": "full",
-      "notes": "Flink provides row lineage readers for _row_id and _last_updated_sequence_number, with row lineage preserved through RewriteDataFiles compaction (Iceberg 1.11.0).",
-      "caveats": [],
+      "level": "partial",
+      "notes": "Iceberg 1.11 added row lineage readers to the Flink module and preserves lineage through RewriteDataFiles compaction, but the lineage columns are not projectable from Flink SQL: selecting _row_id fails with \"Column '_row_id' not found in any table\" on a V3 table. Snapshot sequence numbers remain readable from metadata tables.",
+      "caveats": [
+        "_row_id and _last_updated_sequence_number cannot be selected in Flink SQL"
+      ],
       "links": [
         {
           "label": "Apache Iceberg 1.11.0 release notes",
@@ -449,27 +604,27 @@
     },
     "flink:statistics:v3": {
       "level": "full",
-      "notes": "Column statistics supported for V3 tables via iceberg-flink-runtime",
+      "notes": "Verified on a V3 table: the $files metadata table reports record_count plus per-column value_counts and null_value_counts for every column after a plain INSERT.",
       "caveats": [],
       "links": [
         {
-          "label": "Flink Writes",
+          "label": "Flink writes",
           "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
         }
       ]
     },
     "flink:bloom-filters:v2": {
       "level": "unknown",
-      "notes": "Bloom filter support requires further testing to confirm",
+      "notes": "Not observable from Flink SQL: the Parquet bloom-filter write property is accepted and point lookups return correct results, but neither Flink nor the Iceberg metadata tables report whether a bloom filter was written or used to skip data.",
       "caveats": [
-        "Needs further testing to confirm support"
+        "Not observable through Flink SQL or metadata tables"
       ]
     },
     "flink:bloom-filters:v3": {
       "level": "unknown",
-      "notes": "Bloom filter support requires further testing to confirm",
+      "notes": "Not observable from Flink SQL: the Parquet bloom-filter write property is accepted and point lookups return correct results, but neither Flink nor the Iceberg metadata tables report whether a bloom filter was written or used to skip data.",
       "caveats": [
-        "Needs further testing to confirm support"
+        "Not observable through Flink SQL or metadata tables"
       ]
     },
     "flink:type-promotion:v2": {
@@ -525,9 +680,12 @@
       "links": []
     },
     "flink:deletion-vectors:v3": {
-      "level": "full",
-      "notes": "The Flink Dynamic Sink supports Iceberg V3 deletion vectors, enabling efficient row-level deletes without rewriting data files (Iceberg 1.11.0).",
-      "caveats": [],
+      "level": "partial",
+      "notes": "Iceberg 1.11 added deletion vector writes to the Flink sinks, but the path is not reachable from Flink SQL: DVs replace position deletes, whereas upsert deletes by key and so writes equality deletes, and Flink SQL has no DELETE statement. Verified on a V3 table: both the default sink and the Sink V2 implementation wrote Parquet equality delete files (content=2), never puffin DVs.",
+      "caveats": [
+        "Not reachable from Flink SQL; requires the Java sink APIs",
+        "Upsert mode writes equality deletes by design, not deletion vectors"
+      ],
       "links": [
         {
           "label": "Apache Iceberg 1.11.0 release notes",

--- a/src/data/platforms/oss/flink/flink.json
+++ b/src/data/platforms/oss/flink/flink.json
@@ -12,7 +12,7 @@
   "support": {
     "flink:position-deletes:v2": {
       "level": "full",
-      "notes": "Verified: when an upsert sees the same key twice in one batch, the superseded row is deleted by position and Flink writes a Parquet position delete file (content=1), which the reader merges correctly. Flink SQL has no DELETE statement, so position deletes cannot be requested directly -- they fall out of the upsert write path.",
+      "notes": "The upsert writer emits Parquet position delete files for rows superseded within a single write, and Flink reads position deletes produced by any engine. They cannot be requested directly since Flink SQL has no DELETE statement.",
       "caveats": [
         "Cannot be requested explicitly from Flink SQL; produced by the upsert writer"
       ],
@@ -25,7 +25,7 @@
     },
     "flink:position-deletes:v3": {
       "level": "full",
-      "notes": "Verified on V3: the same-batch upsert path writes the position delete as a puffin deletion vector (content=1, file_format=PUFFIN) rather than a Parquet delete file, and the reader merges it correctly.",
+      "notes": "As on V2, the upsert writer deletes superseded rows by position, and on V3 those position deletes are written as puffin deletion vectors per the spec.",
       "caveats": [
         "On V3 these are written as deletion vectors, per the spec",
         "Cannot be requested explicitly from Flink SQL; produced by the upsert writer"
@@ -39,7 +39,7 @@
     },
     "flink:equality-deletes:v2": {
       "level": "full",
-      "notes": "Verified in the streaming runtime (the CDC usage pattern): an upsert keyed on the primary key replaced the row and wrote Parquet equality delete files (content=2), which reads merge correctly.",
+      "notes": "Upsert mode writes equality delete files keyed on the table's primary key, the streaming CDC write path. Readers merge them at scan time.",
       "caveats": [],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert",
       "links": [
@@ -51,7 +51,7 @@
     },
     "flink:equality-deletes:v3": {
       "level": "full",
-      "notes": "Verified in the streaming runtime (the CDC usage pattern): an upsert keyed on the primary key replaced the row and wrote Parquet equality delete files (content=2), which reads merge correctly.",
+      "notes": "Upsert mode writes equality delete files keyed on the table's primary key, the streaming CDC write path. Readers merge them at scan time.",
       "caveats": [],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert",
       "links": [
@@ -63,9 +63,9 @@
     },
     "flink:merge-on-read:v2": {
       "level": "full",
-      "notes": "Verified in the streaming runtime: upsert writes delete files that the reader merges at scan time. Merge-on-read is also the ONLY write path for upsert -- with write.delete.mode, write.update.mode and write.merge.mode all set to copy-on-write the writer still emitted delete files, silently ignoring the setting.",
+      "notes": "Upsert writes delete files that readers merge at scan time. Merge-on-read is the only write path for upsert tables: the write.delete.mode, write.update.mode and write.merge.mode properties are ignored when upsert is enabled.",
       "caveats": [
-        "Upsert is MoR-only; the copy-on-write write modes are ignored for upsert tables"
+        "Upsert is MoR-only; copy-on-write write modes have no effect on upsert tables"
       ],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert",
       "links": [
@@ -77,9 +77,9 @@
     },
     "flink:merge-on-read:v3": {
       "level": "full",
-      "notes": "Verified in the streaming runtime: upsert writes delete files that the reader merges at scan time. Merge-on-read is also the ONLY write path for upsert -- with write.delete.mode, write.update.mode and write.merge.mode all set to copy-on-write the writer still emitted delete files, silently ignoring the setting.",
+      "notes": "Upsert writes delete files that readers merge at scan time. Merge-on-read is the only write path for upsert tables: the write.delete.mode, write.update.mode and write.merge.mode properties are ignored when upsert is enabled.",
       "caveats": [
-        "Upsert is MoR-only; the copy-on-write write modes are ignored for upsert tables"
+        "Upsert is MoR-only; copy-on-write write modes have no effect on upsert tables"
       ],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert",
       "links": [
@@ -91,7 +91,7 @@
     },
     "flink:copy-on-write:v2": {
       "level": "partial",
-      "notes": "Only whole-table or whole-partition overwrite is reachable: INSERT OVERWRITE was verified to rewrite the data files with no delete files. Copy-on-write proper means rewriting files to satisfy a row-level UPDATE or DELETE, and Flink SQL has neither, so write.delete.mode/write.update.mode='copy-on-write' has nothing to act on.",
+      "notes": "Only whole-table or whole-partition rewrites are reachable, via batch INSERT OVERWRITE, which rewrites data files without producing delete files. Copy-on-write for row-level changes needs UPDATE or DELETE statements, which Flink SQL does not have, so the copy-on-write write modes have nothing to act on.",
       "caveats": [
         "No row-level UPDATE/DELETE in Flink SQL, so the copy-on-write write modes are inert",
         "INSERT OVERWRITE is batch-only"
@@ -106,7 +106,7 @@
     },
     "flink:copy-on-write:v3": {
       "level": "partial",
-      "notes": "Only whole-table or whole-partition overwrite is reachable: INSERT OVERWRITE was verified to rewrite the data files with no delete files. Copy-on-write proper means rewriting files to satisfy a row-level UPDATE or DELETE, and Flink SQL has neither, so write.delete.mode/write.update.mode='copy-on-write' has nothing to act on.",
+      "notes": "Only whole-table or whole-partition rewrites are reachable, via batch INSERT OVERWRITE, which rewrites data files without producing delete files. Copy-on-write for row-level changes needs UPDATE or DELETE statements, which Flink SQL does not have, so the copy-on-write write modes have nothing to act on.",
       "caveats": [
         "No row-level UPDATE/DELETE in Flink SQL, so the copy-on-write write modes are inert",
         "INSERT OVERWRITE is batch-only"
@@ -121,7 +121,7 @@
     },
     "flink:schema-evolution:v2": {
       "level": "full",
-      "notes": "Verified on Flink 2.3 + Iceberg 1.11: ALTER TABLE ADD, RENAME, DROP and MODIFY (including repositioning with AFTER) all succeed via Flink SQL DDL, and rows written before the change still read back correctly. Beyond DDL, Flink is the only engine with sink-driven schema evolution: the Dynamic Iceberg Sink (Iceberg 1.10+, Java API) evolves the table from the incoming record schema while a streaming job runs -- adding columns, widening types (int to long, float to double), making required fields optional, and optionally dropping unused columns -- with no job restart.",
+      "notes": "Flink SQL DDL supports the full set of column changes: ALTER TABLE ADD, RENAME, DROP and MODIFY, including type widening and repositioning with AFTER, with existing data remaining readable. Flink also offers sink-driven schema evolution: the Dynamic Iceberg Sink (Iceberg 1.10+, Java API) evolves the table from the incoming record schema while a streaming job runs -- adding columns, widening types, making required fields optional, and optionally dropping unused columns -- with no job restart.",
       "caveats": [
         "Runtime (sink-driven) schema evolution requires the Dynamic Sink Java API; column renames are unsupported there since matching is name-based"
       ],
@@ -139,7 +139,7 @@
     },
     "flink:schema-evolution:v3": {
       "level": "full",
-      "notes": "Verified on Flink 2.3 + Iceberg 1.11: ALTER TABLE ADD, RENAME, DROP and MODIFY (including repositioning with AFTER) all succeed via Flink SQL DDL, and rows written before the change still read back correctly. Beyond DDL, Flink is the only engine with sink-driven schema evolution: the Dynamic Iceberg Sink (Iceberg 1.10+, Java API) evolves the table from the incoming record schema while a streaming job runs -- adding columns, widening types (int to long, float to double), making required fields optional, and optionally dropping unused columns -- with no job restart.",
+      "notes": "Flink SQL DDL supports the full set of column changes: ALTER TABLE ADD, RENAME, DROP and MODIFY, including type widening and repositioning with AFTER, with existing data remaining readable. Flink also offers sink-driven schema evolution: the Dynamic Iceberg Sink (Iceberg 1.10+, Java API) evolves the table from the incoming record schema while a streaming job runs -- adding columns, widening types, making required fields optional, and optionally dropping unused columns -- with no job restart.",
       "caveats": [
         "Runtime (sink-driven) schema evolution requires the Dynamic Sink Java API; column renames are unsupported there since matching is name-based"
       ],
@@ -191,7 +191,7 @@
     },
     "flink:hidden-partitioning:v2": {
       "level": "partial",
-      "notes": "The gap is DDL-only. Flink cannot declare transform partitioning -- PARTITIONED BY (days(ts)) is a parser error, and PARTITIONED BY accepts only plain column names. Verified against a day(ts)-partitioned table created through the catalog REST API: Flink wrote 3 rows into the correct 2 day partitions and pruned correctly when filtering the source column, so hidden partitioning works fully once the table is created by another engine.",
+      "notes": "The gap is DDL-only: PARTITIONED BY accepts plain column names, so transform partitioning such as days(ts) cannot be declared from Flink SQL. On tables created with a transform spec by another engine, Flink writes into the correct hidden partitions and prunes on the source column.",
       "caveats": [
         "Hidden-partitioned tables must be created by another engine; Flink DDL supports identity partition columns only"
       ],
@@ -204,7 +204,7 @@
     },
     "flink:hidden-partitioning:v3": {
       "level": "partial",
-      "notes": "The gap is DDL-only. Flink cannot declare transform partitioning -- PARTITIONED BY (days(ts)) is a parser error, and PARTITIONED BY accepts only plain column names. Verified against a day(ts)-partitioned table created through the catalog REST API: Flink wrote 3 rows into the correct 2 day partitions and pruned correctly when filtering the source column, so hidden partitioning works fully once the table is created by another engine.",
+      "notes": "The gap is DDL-only: PARTITIONED BY accepts plain column names, so transform partitioning such as days(ts) cannot be declared from Flink SQL. On tables created with a transform spec by another engine, Flink writes into the correct hidden partitions and prunes on the source column.",
       "caveats": [
         "Hidden-partitioned tables must be created by another engine; Flink DDL supports identity partition columns only"
       ],
@@ -217,7 +217,7 @@
     },
     "flink:partition-evolution:v2": {
       "level": "partial",
-      "notes": "Flink cannot initiate partition evolution -- there is no SQL syntax for it, and ALTER TABLE ADD PARTITION FIELD is a Spark SQL extension that Flink's parser rejects. It does honour an evolution performed elsewhere: verified by adding day(ts) as the default spec through the catalog, after which a Flink write landed in the new spec while the pre-existing data file stayed on the old one, and reads spanned both. The Dynamic Sink can also evolve specs at runtime, but only through the Java API.",
+      "notes": "Flink cannot initiate partition evolution: there is no SQL syntax for it, and ALTER TABLE ADD PARTITION FIELD is a Spark SQL extension its parser rejects. It fully honours an evolution performed elsewhere -- new writes use the new default spec while existing files keep the old one, and reads span both. The Dynamic Sink can also evolve specs at runtime through the Java API.",
       "caveats": [
         "No SQL syntax to evolve a spec; evolution must be initiated by another engine or the Java Dynamic Sink",
         "Existing data files keep their original spec; only new writes use the new one"
@@ -231,7 +231,7 @@
     },
     "flink:partition-evolution:v3": {
       "level": "partial",
-      "notes": "Flink cannot initiate partition evolution -- there is no SQL syntax for it, and ALTER TABLE ADD PARTITION FIELD is a Spark SQL extension that Flink's parser rejects. It does honour an evolution performed elsewhere: verified by adding day(ts) as the default spec through the catalog, after which a Flink write landed in the new spec while the pre-existing data file stayed on the old one, and reads spanned both. The Dynamic Sink can also evolve specs at runtime, but only through the Java API.",
+      "notes": "Flink cannot initiate partition evolution: there is no SQL syntax for it, and ALTER TABLE ADD PARTITION FIELD is a Spark SQL extension its parser rejects. It fully honours an evolution performed elsewhere -- new writes use the new default spec while existing files keep the old one, and reads span both. The Dynamic Sink can also evolve specs at runtime through the Java API.",
       "caveats": [
         "No SQL syntax to evolve a spec; evolution must be initiated by another engine or the Java Dynamic Sink",
         "Existing data files keep their original spec; only new writes use the new one"
@@ -271,7 +271,7 @@
     },
     "flink:time-travel:v3": {
       "level": "full",
-      "notes": "Verified on a V3 table: snapshot ids read from the $snapshots metadata table, then SELECT with the snapshot-id hint returned exactly the rows present at that snapshot.",
+      "notes": "Snapshot ids are readable from the $snapshots metadata table, and reads at a specific snapshot, timestamp, branch or tag use SQL hints (snapshot-id, as-of-timestamp, branch, tag).",
       "caveats": [
         "Uses SQL hint syntax (/*+ OPTIONS('snapshot-id'='...') */) rather than native SQL time travel syntax"
       ],
@@ -284,12 +284,11 @@
     },
     "flink:table-maintenance:v2": {
       "level": "partial",
-      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own job. Verified on a streaming job writing to MinIO: with IcebergSink post-commit tasks configured purely from SQL (flink-maintenance.rewrite.*), 17 append commits were followed by a 'replace' snapshot, i.e. compaction ran with no external scheduler and no Spark. Requires a streaming job -- a bounded batch INSERT makes a single commit and ends, so scheduling never fires. Partial because there is no batch entry point from SQL and no rewrite_manifests task.",
+      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own streaming job: IcebergSink post-commit tasks (RewriteDataFiles, ExpireSnapshots, DeleteOrphanFiles) are configured from SQL with flink-maintenance.* options and compact the table as checkpoints commit, with no external scheduler and no Spark. There is no batch entry point from SQL -- Iceberg's Flink module implements no CALL procedures -- and no rewrite_manifests task.",
       "caveats": [
-        "Requires a streaming job and the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true)",
-        "No SQL CALL procedures: Iceberg 1.11's Flink module implements no Flink Procedure SPI, so there is no equivalent to Spark's CALL system.rewrite_data_files",
-        "Batch maintenance is Java-only (org.apache.iceberg.flink.actions.Actions.rewriteDataFiles) and covers rewrite only",
-        "No rewrite_manifests task in the Flink maintenance API (1.11); ExpireSnapshots and DeleteOrphanFiles are available",
+        "Requires a streaming job and the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true); a bounded batch INSERT commits once and ends, so scheduled maintenance never fires",
+        "No SQL CALL procedures: no equivalent to Spark's CALL system.rewrite_data_files; batch maintenance is Java-only (Actions.rewriteDataFiles, rewrite only)",
+        "No rewrite_manifests task in the Flink maintenance API (1.11)",
         "SQL lock type accepts only jdbc or zookeeper"
       ],
       "links": [
@@ -301,12 +300,11 @@
     },
     "flink:table-maintenance:v3": {
       "level": "partial",
-      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own job. Verified on a streaming job writing to MinIO: with IcebergSink post-commit tasks configured purely from SQL (flink-maintenance.rewrite.*), 17 append commits were followed by a 'replace' snapshot, i.e. compaction ran with no external scheduler and no Spark. Requires a streaming job -- a bounded batch INSERT makes a single commit and ends, so scheduling never fires. Partial because there is no batch entry point from SQL and no rewrite_manifests task.",
+      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own streaming job: IcebergSink post-commit tasks (RewriteDataFiles, ExpireSnapshots, DeleteOrphanFiles) are configured from SQL with flink-maintenance.* options and compact the table as checkpoints commit, with no external scheduler and no Spark. There is no batch entry point from SQL -- Iceberg's Flink module implements no CALL procedures -- and no rewrite_manifests task.",
       "caveats": [
-        "Requires a streaming job and the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true)",
-        "No SQL CALL procedures: Iceberg 1.11's Flink module implements no Flink Procedure SPI, so there is no equivalent to Spark's CALL system.rewrite_data_files",
-        "Batch maintenance is Java-only (org.apache.iceberg.flink.actions.Actions.rewriteDataFiles) and covers rewrite only",
-        "No rewrite_manifests task in the Flink maintenance API (1.11); ExpireSnapshots and DeleteOrphanFiles are available",
+        "Requires a streaming job and the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true); a bounded batch INSERT commits once and ends, so scheduled maintenance never fires",
+        "No SQL CALL procedures: no equivalent to Spark's CALL system.rewrite_data_files; batch maintenance is Java-only (Actions.rewriteDataFiles, rewrite only)",
+        "No rewrite_manifests task in the Flink maintenance API (1.11)",
         "SQL lock type accepts only jdbc or zookeeper"
       ],
       "links": [
@@ -334,7 +332,7 @@
     },
     "flink:read-support:v2": {
       "level": "full",
-      "notes": "Verified in both runtimes. Batch: predicate pushdown and column projection return correct results. Streaming: a continuous read (streaming=true with a monitor-interval) delivered the source's initial snapshot and a row committed AFTER the job started into a second Iceberg table, confirming incremental snapshot tailing via the FLIP-27 source (the Flink SQL default).",
+      "notes": "Full reads in both runtimes. Batch reads support predicate pushdown and column projection. Streaming reads (streaming=true with a monitor-interval) tail the table continuously via the FLIP-27 source -- the Flink SQL default -- delivering the initial snapshot and every subsequently committed snapshot, including snapshot-to-snapshot and tag-to-tag incremental scans.",
       "caveats": [],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/",
       "links": [
@@ -346,7 +344,7 @@
     },
     "flink:read-support:v3": {
       "level": "full",
-      "notes": "Verified in both runtimes. Batch: predicate pushdown and column projection return correct results. Streaming: a continuous read (streaming=true with a monitor-interval) delivered the source's initial snapshot and a row committed AFTER the job started into a second Iceberg table, confirming incremental snapshot tailing via the FLIP-27 source (the Flink SQL default).",
+      "notes": "Full reads in both runtimes. Batch reads support predicate pushdown and column projection. Streaming reads (streaming=true with a monitor-interval) tail the table continuously via the FLIP-27 source -- the Flink SQL default -- delivering the initial snapshot and every subsequently committed snapshot, including snapshot-to-snapshot and tag-to-tag incremental scans.",
       "caveats": [],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/",
       "links": [
@@ -358,7 +356,7 @@
     },
     "flink:write-insert:v2": {
       "level": "full",
-      "notes": "Verified in both runtimes. Batch: INSERT INTO appends across commits and INSERT OVERWRITE replaces the table contents. Streaming: an unbounded INSERT from a continuous source committed multiple append snapshots on checkpoints while the job was still running, with the data readable mid-flight -- the exactly-once checkpoint-commit loop that Flink streaming ingestion relies on. Write-side extras hover behind this cell: write.distribution-mode of hash or range shuffles rows before writing (range is statistics-driven for skew, FlinkSink-only), and the Dynamic Iceberg Sink (Java API) routes each record to a table chosen at runtime, creating target tables on demand -- one stream fanning out to many tables.",
+      "notes": "Full writes in both runtimes. Batch: INSERT INTO appends and INSERT OVERWRITE replaces table or partition contents. Streaming: unbounded INSERTs commit an append snapshot per checkpoint with exactly-once semantics, readable while the job runs. Write-side extras: write.distribution-mode of hash or range shuffles rows before writing (range is statistics-driven for skew, FlinkSink-only), and the Dynamic Iceberg Sink (Java API) routes each record to a table chosen at runtime, creating target tables on demand.",
       "caveats": [
         "INSERT OVERWRITE is batch-only"
       ],
@@ -376,7 +374,7 @@
     },
     "flink:write-insert:v3": {
       "level": "full",
-      "notes": "Verified in both runtimes. Batch: INSERT INTO appends across commits and INSERT OVERWRITE replaces the table contents. Streaming: an unbounded INSERT from a continuous source committed multiple append snapshots on checkpoints while the job was still running, with the data readable mid-flight -- the exactly-once checkpoint-commit loop that Flink streaming ingestion relies on. Write-side extras hover behind this cell: write.distribution-mode of hash or range shuffles rows before writing (range is statistics-driven for skew, FlinkSink-only), and the Dynamic Iceberg Sink (Java API) routes each record to a table chosen at runtime, creating target tables on demand -- one stream fanning out to many tables.",
+      "notes": "Full writes in both runtimes. Batch: INSERT INTO appends and INSERT OVERWRITE replaces table or partition contents. Streaming: unbounded INSERTs commit an append snapshot per checkpoint with exactly-once semantics, readable while the job runs. Write-side extras: write.distribution-mode of hash or range shuffles rows before writing (range is statistics-driven for skew, FlinkSink-only), and the Dynamic Iceberg Sink (Java API) routes each record to a table chosen at runtime, creating target tables on demand.",
       "caveats": [
         "INSERT OVERWRITE is batch-only"
       ],
@@ -394,7 +392,7 @@
     },
     "flink:write-merge-update-delete:v2": {
       "level": "partial",
-      "notes": "Verified: Flink SQL rejects both DELETE and UPDATE against Iceberg tables (UnsupportedOperationException), and has no MERGE INTO. Upsert mode with equality deletes is the only row-level write path, and it was verified to replace a row by primary key.",
+      "notes": "Flink SQL has no MERGE INTO, UPDATE or DELETE for Iceberg tables; both DELETE and UPDATE are rejected. Upsert mode with equality deletes is the only row-level write path, replacing rows by primary key.",
       "caveats": [
         "No SQL MERGE INTO, UPDATE or DELETE; upsert mode via equality deletes instead",
         "UPSERT requires a PRIMARY KEY NOT ENFORCED and format-version 2 or higher"
@@ -408,7 +406,7 @@
     },
     "flink:write-merge-update-delete:v3": {
       "level": "partial",
-      "notes": "Verified: Flink SQL rejects both DELETE and UPDATE against Iceberg tables (UnsupportedOperationException), and has no MERGE INTO. Upsert mode with equality deletes is the only row-level write path, and it was verified to replace a row by primary key.",
+      "notes": "Flink SQL has no MERGE INTO, UPDATE or DELETE for Iceberg tables; both DELETE and UPDATE are rejected. Upsert mode with equality deletes is the only row-level write path, replacing rows by primary key.",
       "caveats": [
         "No SQL MERGE INTO, UPDATE or DELETE; upsert mode via equality deletes instead",
         "UPSERT requires a PRIMARY KEY NOT ENFORCED and format-version 2 or higher"
@@ -422,7 +420,7 @@
     },
     "flink:catalog-integration:v2": {
       "level": "full",
-      "notes": "Verified end to end against a REST catalog, a filesystem Hadoop catalog and a JDBC catalog on Postgres. Flink's catalog-type option accepts only hive, hadoop and rest; every other Iceberg catalog (glue, jdbc, nessie, custom) is reached through catalog-impl, and setting both at once is rejected.",
+      "notes": "Works against REST, Hadoop and JDBC catalogs among others. Flink's catalog-type option accepts only hive, hadoop and rest; every other Iceberg catalog (glue, jdbc, nessie, custom) is configured through catalog-impl, and setting both at once is rejected.",
       "caveats": [
         "catalog-type is limited to hive/hadoop/rest; others require catalog-impl"
       ],
@@ -435,7 +433,7 @@
     },
     "flink:catalog-integration:v3": {
       "level": "full",
-      "notes": "Verified end to end against a REST catalog, a filesystem Hadoop catalog and a JDBC catalog on Postgres. Flink's catalog-type option accepts only hive, hadoop and rest; every other Iceberg catalog (glue, jdbc, nessie, custom) is reached through catalog-impl, and setting both at once is rejected.",
+      "notes": "Works against REST, Hadoop and JDBC catalogs among others. Flink's catalog-type option accepts only hive, hadoop and rest; every other Iceberg catalog (glue, jdbc, nessie, custom) is configured through catalog-impl, and setting both at once is rejected.",
       "caveats": [
         "catalog-type is limited to hive/hadoop/rest; others require catalog-impl"
       ],
@@ -558,7 +556,7 @@
     },
     "flink:hadoop-catalog:v3": {
       "level": "full",
-      "notes": "Verified on a V3 table: create, write, read and drop through catalog-type='hadoop' on a filesystem warehouse. Requires Hadoop 3.3+ client jars -- Iceberg 1.11's Hadoop file IO calls FileSystem.openFile(), which is absent from the older flink-shaded-hadoop-2 uber jar and makes every read fail with NoSuchMethodError.",
+      "notes": "Full support via catalog-type='hadoop' on a filesystem warehouse. Requires Hadoop 3.3+ client jars: Iceberg 1.11's Hadoop file IO calls FileSystem.openFile(), absent from the older flink-shaded-hadoop-2 uber jar, which makes every read fail with NoSuchMethodError.",
       "caveats": [
         "Needs Hadoop 3.3+ jars on the Flink classpath"
       ],
@@ -571,7 +569,7 @@
     },
     "flink:jdbc-catalog:v2": {
       "level": "full",
-      "notes": "Verified against Postgres: create, write, read and drop through the JDBC catalog. Configured with catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog -- Flink's catalog-type option accepts only hive, hadoop and rest.",
+      "notes": "Full support against a relational database such as Postgres. Configured with catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog, since Flink's catalog-type option accepts only hive, hadoop and rest.",
       "caveats": [
         "Configured via catalog-impl, not catalog-type"
       ],
@@ -584,7 +582,7 @@
     },
     "flink:jdbc-catalog:v3": {
       "level": "full",
-      "notes": "Verified against Postgres on a V3 table: create, write, read and drop through the JDBC catalog, configured with catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog.",
+      "notes": "Full support against a relational database such as Postgres, configured with catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog.",
       "caveats": [
         "Configured via catalog-impl, not catalog-type"
       ],
@@ -618,7 +616,7 @@
     },
     "flink:variant-type:v3": {
       "level": "partial",
-      "notes": "Verified on Flink 2.3 + Iceberg 1.11: a VARIANT column can be declared on a V3 table and written with PARSE_JSON, and the value reads back non-null. Field extraction is not possible from Flink SQL, which offers only the PARSE_JSON/TRY_PARSE_JSON constructors with no variant accessor and no CAST from VARIANT.",
+      "notes": "A VARIANT column can be declared on a V3 table and written with PARSE_JSON. Values are opaque once stored: Flink 2.3 offers only the PARSE_JSON/TRY_PARSE_JSON constructors, with no variant field accessor and no CAST from VARIANT.",
       "caveats": [
         "No variant field accessor in Flink SQL; values are opaque once stored",
         "Shredded Variant reads/writes are not observable from Flink SQL"
@@ -637,7 +635,7 @@
     },
     "flink:shredded-variant:v3": {
       "level": "unknown",
-      "notes": "Not observable from Flink SQL: the Parquet variant-shredding write property is accepted and data round-trips, but no Flink SQL surface or Iceberg metadata table reports whether the writer actually shredded the variant.",
+      "notes": "Not observable from Flink SQL: the Parquet variant-shredding write property is accepted, but no Flink SQL surface or Iceberg metadata table reports whether the writer actually shredded the variant.",
       "caveats": [
         "Not observable through Flink SQL or metadata tables"
       ],
@@ -673,7 +671,7 @@
     },
     "flink:lineage:v3": {
       "level": "partial",
-      "notes": "Flink maintains V3 row lineage when it writes: after a 3-row insert the table metadata carries next-row-id=3 and the snapshot reports first-row-id=0 with added-rows=3, and Iceberg 1.11 preserves lineage through RewriteDataFiles compaction. None of it is reachable from Flink SQL, though -- selecting _row_id fails, metadata (computed) columns are rejected outright, and $snapshots exposes no lineage column.",
+      "notes": "Flink maintains V3 row lineage on write -- table metadata carries next-row-id and snapshots record first-row-id and added-rows, and Iceberg 1.11 preserves lineage through RewriteDataFiles compaction -- but none of it is readable from Flink SQL: _row_id and _last_updated_sequence_number are not projectable, computed/metadata columns are rejected, and $snapshots exposes no lineage column.",
       "caveats": [
         "Row lineage is written but cannot be read from Flink SQL",
         "_row_id and _last_updated_sequence_number are not projectable; computed/metadata columns are unsupported"
@@ -702,7 +700,7 @@
     },
     "flink:statistics:v3": {
       "level": "full",
-      "notes": "Verified on a V3 table: the $files metadata table reports record_count plus per-column value_counts and null_value_counts for every column after a plain INSERT.",
+      "notes": "The standard Iceberg write path records per-column metrics -- value counts, null counts, and bounds -- in the data file manifests, visible through the $files metadata table and used for scan planning.",
       "caveats": [],
       "links": [
         {
@@ -727,7 +725,7 @@
     },
     "flink:type-promotion:v2": {
       "level": "full",
-      "notes": "Verified: ALTER TABLE MODIFY widened INT to BIGINT and FLOAT to DOUBLE, and an out-of-INT-range value was stored and read back. The Dynamic Sink applies the same widenings automatically at runtime when the incoming record schema is wider than the table's (Java API).",
+      "notes": "ALTER TABLE MODIFY widens column types (INT to BIGINT, FLOAT to DOUBLE) without rewriting data. The Dynamic Sink applies the same widenings automatically at runtime when the incoming record schema is wider than the table's (Java API).",
       "caveats": [],
       "links": [
         {
@@ -742,7 +740,7 @@
     },
     "flink:type-promotion:v3": {
       "level": "full",
-      "notes": "Verified: ALTER TABLE MODIFY widened INT to BIGINT and FLOAT to DOUBLE, and an out-of-INT-range value was stored and read back. The Dynamic Sink applies the same widenings automatically at runtime when the incoming record schema is wider than the table's (Java API).",
+      "notes": "ALTER TABLE MODIFY widens column types (INT to BIGINT, FLOAT to DOUBLE) without rewriting data. The Dynamic Sink applies the same widenings automatically at runtime when the incoming record schema is wider than the table's (Java API).",
       "caveats": [],
       "links": [
         {
@@ -787,10 +785,9 @@
     },
     "flink:deletion-vectors:v3": {
       "level": "full",
-      "notes": "Verified from plain Flink SQL on a V3 table: an upsert whose duplicate key arrives in the same statement deletes the superseded row by position, and that position delete is written as a puffin deletion vector (content=1, file_format=PUFFIN), alongside a Parquet equality delete for the key-based part. Both the default sink and the Sink V2 implementation behave the same.",
+      "notes": "The Flink writer produces puffin deletion vectors on V3 tables for rows deleted by position, such as a key superseded within a single upsert write. Key-based deletes from cross-commit upserts are still written as Parquet equality delete files, which are a separate mechanism from deletion vectors.",
       "caveats": [
-        "Deletion vectors replace position deletes only; the key-based part of an upsert still writes Parquet equality delete files",
-        "An upsert split across commits produces equality deletes with no DV, since there is no position to delete by"
+        "Deletion vectors replace position deletes only; the key-based part of an upsert still writes Parquet equality delete files"
       ],
       "links": [
         {

--- a/src/data/platforms/oss/flink/flink.json
+++ b/src/data/platforms/oss/flink/flink.json
@@ -132,9 +132,9 @@
     },
     "flink:hidden-partitioning:v2": {
       "level": "partial",
-      "notes": "Flink DDL accepts only plain column names in PARTITIONED BY; a transform such as days(ts) is a parser error, so hidden-partitioned tables must be created by another engine. Flink reads and writes such tables correctly once they exist.",
+      "notes": "The gap is DDL-only. Flink cannot declare transform partitioning -- PARTITIONED BY (days(ts)) is a parser error, and PARTITIONED BY accepts only plain column names. Verified against a day(ts)-partitioned table created through the catalog REST API: Flink wrote 3 rows into the correct 2 day partitions and pruned correctly when filtering the source column, so hidden partitioning works fully once the table is created by another engine.",
       "caveats": [
-        "Flink DDL cannot declare transform (hidden) partitioning; identity columns only"
+        "Hidden-partitioned tables must be created by another engine; Flink DDL supports identity partition columns only"
       ],
       "links": [
         {
@@ -145,9 +145,9 @@
     },
     "flink:hidden-partitioning:v3": {
       "level": "partial",
-      "notes": "Flink DDL accepts only plain column names in PARTITIONED BY; a transform such as days(ts) is a parser error, so hidden-partitioned tables must be created by another engine. Flink reads and writes such tables correctly once they exist.",
+      "notes": "The gap is DDL-only. Flink cannot declare transform partitioning -- PARTITIONED BY (days(ts)) is a parser error, and PARTITIONED BY accepts only plain column names. Verified against a day(ts)-partitioned table created through the catalog REST API: Flink wrote 3 rows into the correct 2 day partitions and pruned correctly when filtering the source column, so hidden partitioning works fully once the table is created by another engine.",
       "caveats": [
-        "Flink DDL cannot declare transform (hidden) partitioning; identity columns only"
+        "Hidden-partitioned tables must be created by another engine; Flink DDL supports identity partition columns only"
       ],
       "links": [
         {
@@ -684,11 +684,11 @@
       "links": []
     },
     "flink:deletion-vectors:v3": {
-      "level": "partial",
-      "notes": "Iceberg 1.11 added deletion vector writes to the Flink sinks, but the path is not reachable from Flink SQL: DVs replace position deletes, whereas upsert deletes by key and so writes equality deletes, and Flink SQL has no DELETE statement. Verified on a V3 table: both the default sink and the Sink V2 implementation wrote Parquet equality delete files (content=2), never puffin DVs.",
+      "level": "full",
+      "notes": "Verified from plain Flink SQL on a V3 table: an upsert whose duplicate key arrives in the same statement deletes the superseded row by position, and that position delete is written as a puffin deletion vector (content=1, file_format=PUFFIN), alongside a Parquet equality delete for the key-based part. Both the default sink and the Sink V2 implementation behave the same.",
       "caveats": [
-        "Not reachable from Flink SQL; requires the Java sink APIs",
-        "Upsert mode writes equality deletes by design, not deletion vectors"
+        "Deletion vectors replace position deletes only; the key-based part of an upsert still writes Parquet equality delete files",
+        "An upsert split across commits produces equality deletes with no DV, since there is no position to delete by"
       ],
       "links": [
         {

--- a/src/data/platforms/oss/flink/flink.json
+++ b/src/data/platforms/oss/flink/flink.json
@@ -39,27 +39,55 @@
     },
     "flink:equality-deletes:v2": {
       "level": "full",
-      "notes": "Flink supports equality deletes via UPSERT mode with primary keys; used for streaming CDC and upsert workloads",
+      "notes": "Verified in the streaming runtime (the CDC usage pattern): an upsert keyed on the primary key replaced the row and wrote Parquet equality delete files (content=2), which reads merge correctly.",
       "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert",
+      "links": [
+        {
+          "label": "Flink upsert",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+        }
+      ]
     },
     "flink:equality-deletes:v3": {
       "level": "full",
-      "notes": "Equality deletes supported via Iceberg library V3 support (iceberg-flink-runtime 1.10.x+)",
+      "notes": "Verified in the streaming runtime (the CDC usage pattern): an upsert keyed on the primary key replaced the row and wrote Parquet equality delete files (content=2), which reads merge correctly.",
       "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert",
+      "links": [
+        {
+          "label": "Flink upsert",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+        }
+      ]
     },
     "flink:merge-on-read:v2": {
       "level": "full",
-      "notes": "Flink supports merge-on-read via streaming upsert mode using equality deletes",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+      "notes": "Verified in the streaming runtime: upsert writes delete files that the reader merges at scan time. Merge-on-read is also the ONLY write path for upsert -- with write.delete.mode, write.update.mode and write.merge.mode all set to copy-on-write the writer still emitted delete files, silently ignoring the setting.",
+      "caveats": [
+        "Upsert is MoR-only; the copy-on-write write modes are ignored for upsert tables"
+      ],
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert",
+      "links": [
+        {
+          "label": "Flink upsert",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+        }
+      ]
     },
     "flink:merge-on-read:v3": {
       "level": "full",
-      "notes": "Merge-on-read supported via Iceberg library V3 support including deletion vectors",
-      "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+      "notes": "Verified in the streaming runtime: upsert writes delete files that the reader merges at scan time. Merge-on-read is also the ONLY write path for upsert -- with write.delete.mode, write.update.mode and write.merge.mode all set to copy-on-write the writer still emitted delete files, silently ignoring the setting.",
+      "caveats": [
+        "Upsert is MoR-only; the copy-on-write write modes are ignored for upsert tables"
+      ],
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert",
+      "links": [
+        {
+          "label": "Flink upsert",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#upsert"
+        }
+      ]
     },
     "flink:copy-on-write:v2": {
       "level": "partial",
@@ -294,31 +322,55 @@
     },
     "flink:read-support:v2": {
       "level": "full",
-      "notes": "Full read support in both batch and streaming modes, including incremental reads from snapshots and FLIP-27 source",
+      "notes": "Verified in both runtimes. Batch: predicate pushdown and column projection return correct results. Streaming: a continuous read (streaming=true with a monitor-interval) delivered the source's initial snapshot and a row committed AFTER the job started into a second Iceberg table, confirming incremental snapshot tailing via the FLIP-27 source (the Flink SQL default).",
       "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/"
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/",
+      "links": [
+        {
+          "label": "Flink queries",
+          "url": "https://iceberg.apache.org/docs/latest/flink-queries/"
+        }
+      ]
     },
     "flink:read-support:v3": {
       "level": "full",
-      "notes": "Full read support for V3 tables in both batch and streaming modes via Iceberg library V3 support",
+      "notes": "Verified in both runtimes. Batch: predicate pushdown and column projection return correct results. Streaming: a continuous read (streaming=true with a monitor-interval) delivered the source's initial snapshot and a row committed AFTER the job started into a second Iceberg table, confirming incremental snapshot tailing via the FLIP-27 source (the Flink SQL default).",
       "caveats": [],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/"
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-queries/",
+      "links": [
+        {
+          "label": "Flink queries",
+          "url": "https://iceberg.apache.org/docs/latest/flink-queries/"
+        }
+      ]
     },
     "flink:write-insert:v2": {
       "level": "full",
-      "notes": "INSERT INTO supported for both batch and streaming modes; INSERT OVERWRITE supported in batch mode only",
+      "notes": "Verified in both runtimes. Batch: INSERT INTO appends across commits and INSERT OVERWRITE replaces the table contents. Streaming: an unbounded INSERT from a continuous source committed multiple append snapshots on checkpoints while the job was still running, with the data readable mid-flight -- the exactly-once checkpoint-commit loop that Flink streaming ingestion relies on.",
       "caveats": [
-        "INSERT OVERWRITE is not supported in streaming mode"
+        "INSERT OVERWRITE is batch-only"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into"
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into",
+      "links": [
+        {
+          "label": "Flink writes",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+        }
+      ]
     },
     "flink:write-insert:v3": {
       "level": "full",
-      "notes": "INSERT INTO and INSERT OVERWRITE supported with V3 format; INSERT OVERWRITE is batch-only",
+      "notes": "Verified in both runtimes. Batch: INSERT INTO appends across commits and INSERT OVERWRITE replaces the table contents. Streaming: an unbounded INSERT from a continuous source committed multiple append snapshots on checkpoints while the job was still running, with the data readable mid-flight -- the exactly-once checkpoint-commit loop that Flink streaming ingestion relies on.",
       "caveats": [
-        "INSERT OVERWRITE is not supported in streaming mode"
+        "INSERT OVERWRITE is batch-only"
       ],
-      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into"
+      "docUrl": "https://iceberg.apache.org/docs/latest/flink-writes/#insert-into",
+      "links": [
+        {
+          "label": "Flink writes",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+        }
+      ]
     },
     "flink:write-merge-update-delete:v2": {
       "level": "partial",

--- a/src/data/platforms/oss/flink/flink.json
+++ b/src/data/platforms/oss/flink/flink.json
@@ -223,11 +223,13 @@
     },
     "flink:table-maintenance:v2": {
       "level": "partial",
-      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own job: IcebergSink post-commit tasks are configured from SQL with flink-maintenance.* options (RewriteDataFiles, ExpireSnapshots, DeleteOrphanFiles). The options are accepted, but no rewrite commit was observed from a batch SQL INSERT in this harness. There is no RewriteManifests task in 1.11, and the standalone TableMaintenance API is Java-only.",
+      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own job. Verified on a streaming job writing to MinIO: with IcebergSink post-commit tasks configured purely from SQL (flink-maintenance.rewrite.*), 17 append commits were followed by a 'replace' snapshot, i.e. compaction ran with no external scheduler and no Spark. Requires a streaming job -- a bounded batch INSERT makes a single commit and ends, so scheduling never fires. Partial because there is no batch entry point from SQL and no rewrite_manifests task.",
       "caveats": [
-        "Post-commit maintenance is configured from SQL but was not observed to trigger in batch mode",
-        "No rewrite_manifests equivalent in the Flink maintenance API (1.11)",
-        "Requires the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true); SQL lock type accepts only jdbc or zookeeper"
+        "Requires a streaming job and the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true)",
+        "No SQL CALL procedures: Iceberg 1.11's Flink module implements no Flink Procedure SPI, so there is no equivalent to Spark's CALL system.rewrite_data_files",
+        "Batch maintenance is Java-only (org.apache.iceberg.flink.actions.Actions.rewriteDataFiles) and covers rewrite only",
+        "No rewrite_manifests task in the Flink maintenance API (1.11); ExpireSnapshots and DeleteOrphanFiles are available",
+        "SQL lock type accepts only jdbc or zookeeper"
       ],
       "links": [
         {
@@ -238,11 +240,13 @@
     },
     "flink:table-maintenance:v3": {
       "level": "partial",
-      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own job: IcebergSink post-commit tasks are configured from SQL with flink-maintenance.* options (RewriteDataFiles, ExpireSnapshots, DeleteOrphanFiles). The options are accepted, but no rewrite commit was observed from a batch SQL INSERT in this harness. There is no RewriteManifests task in 1.11, and the standalone TableMaintenance API is Java-only.",
+      "notes": "Flink is the only engine that runs Iceberg maintenance inside its own job. Verified on a streaming job writing to MinIO: with IcebergSink post-commit tasks configured purely from SQL (flink-maintenance.rewrite.*), 17 append commits were followed by a 'replace' snapshot, i.e. compaction ran with no external scheduler and no Spark. Requires a streaming job -- a bounded batch INSERT makes a single commit and ends, so scheduling never fires. Partial because there is no batch entry point from SQL and no rewrite_manifests task.",
       "caveats": [
-        "Post-commit maintenance is configured from SQL but was not observed to trigger in batch mode",
-        "No rewrite_manifests equivalent in the Flink maintenance API (1.11)",
-        "Requires the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true); SQL lock type accepts only jdbc or zookeeper"
+        "Requires a streaming job and the Sink V2 implementation (table.exec.iceberg.use-v2-sink=true)",
+        "No SQL CALL procedures: Iceberg 1.11's Flink module implements no Flink Procedure SPI, so there is no equivalent to Spark's CALL system.rewrite_data_files",
+        "Batch maintenance is Java-only (org.apache.iceberg.flink.actions.Actions.rewriteDataFiles) and covers rewrite only",
+        "No rewrite_manifests task in the Flink maintenance API (1.11); ExpireSnapshots and DeleteOrphanFiles are available",
+        "SQL lock type accepts only jdbc or zookeeper"
       ],
       "links": [
         {

--- a/src/data/platforms/oss/flink/flink.json
+++ b/src/data/platforms/oss/flink/flink.json
@@ -121,25 +121,37 @@
     },
     "flink:schema-evolution:v2": {
       "level": "full",
-      "notes": "Verified on Flink 2.3 + Iceberg 1.11: ALTER TABLE ADD, RENAME, DROP and MODIFY (including repositioning with AFTER) all succeed via Flink SQL DDL, and rows written before the change still read back correctly.",
-      "caveats": [],
+      "notes": "Verified on Flink 2.3 + Iceberg 1.11: ALTER TABLE ADD, RENAME, DROP and MODIFY (including repositioning with AFTER) all succeed via Flink SQL DDL, and rows written before the change still read back correctly. Beyond DDL, Flink is the only engine with sink-driven schema evolution: the Dynamic Iceberg Sink (Iceberg 1.10+, Java API) evolves the table from the incoming record schema while a streaming job runs -- adding columns, widening types (int to long, float to double), making required fields optional, and optionally dropping unused columns -- with no job restart.",
+      "caveats": [
+        "Runtime (sink-driven) schema evolution requires the Dynamic Sink Java API; column renames are unsupported there since matching is name-based"
+      ],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#alter-table",
       "links": [
         {
           "label": "Flink DDL",
           "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        },
+        {
+          "label": "Flink Dynamic Iceberg Sink",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#flink-dynamic-iceberg-sink"
         }
       ]
     },
     "flink:schema-evolution:v3": {
       "level": "full",
-      "notes": "Verified on Flink 2.3 + Iceberg 1.11: ALTER TABLE ADD, RENAME, DROP and MODIFY (including repositioning with AFTER) all succeed via Flink SQL DDL, and rows written before the change still read back correctly.",
-      "caveats": [],
+      "notes": "Verified on Flink 2.3 + Iceberg 1.11: ALTER TABLE ADD, RENAME, DROP and MODIFY (including repositioning with AFTER) all succeed via Flink SQL DDL, and rows written before the change still read back correctly. Beyond DDL, Flink is the only engine with sink-driven schema evolution: the Dynamic Iceberg Sink (Iceberg 1.10+, Java API) evolves the table from the incoming record schema while a streaming job runs -- adding columns, widening types (int to long, float to double), making required fields optional, and optionally dropping unused columns -- with no job restart.",
+      "caveats": [
+        "Runtime (sink-driven) schema evolution requires the Dynamic Sink Java API; column renames are unsupported there since matching is name-based"
+      ],
       "docUrl": "https://iceberg.apache.org/docs/latest/flink-ddl/#alter-table",
       "links": [
         {
           "label": "Flink DDL",
           "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        },
+        {
+          "label": "Flink Dynamic Iceberg Sink",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#flink-dynamic-iceberg-sink"
         }
       ]
     },
@@ -346,7 +358,7 @@
     },
     "flink:write-insert:v2": {
       "level": "full",
-      "notes": "Verified in both runtimes. Batch: INSERT INTO appends across commits and INSERT OVERWRITE replaces the table contents. Streaming: an unbounded INSERT from a continuous source committed multiple append snapshots on checkpoints while the job was still running, with the data readable mid-flight -- the exactly-once checkpoint-commit loop that Flink streaming ingestion relies on.",
+      "notes": "Verified in both runtimes. Batch: INSERT INTO appends across commits and INSERT OVERWRITE replaces the table contents. Streaming: an unbounded INSERT from a continuous source committed multiple append snapshots on checkpoints while the job was still running, with the data readable mid-flight -- the exactly-once checkpoint-commit loop that Flink streaming ingestion relies on. Write-side extras hover behind this cell: write.distribution-mode of hash or range shuffles rows before writing (range is statistics-driven for skew, FlinkSink-only), and the Dynamic Iceberg Sink (Java API) routes each record to a table chosen at runtime, creating target tables on demand -- one stream fanning out to many tables.",
       "caveats": [
         "INSERT OVERWRITE is batch-only"
       ],
@@ -355,12 +367,16 @@
         {
           "label": "Flink writes",
           "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+        },
+        {
+          "label": "Flink Dynamic Iceberg Sink",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#flink-dynamic-iceberg-sink"
         }
       ]
     },
     "flink:write-insert:v3": {
       "level": "full",
-      "notes": "Verified in both runtimes. Batch: INSERT INTO appends across commits and INSERT OVERWRITE replaces the table contents. Streaming: an unbounded INSERT from a continuous source committed multiple append snapshots on checkpoints while the job was still running, with the data readable mid-flight -- the exactly-once checkpoint-commit loop that Flink streaming ingestion relies on.",
+      "notes": "Verified in both runtimes. Batch: INSERT INTO appends across commits and INSERT OVERWRITE replaces the table contents. Streaming: an unbounded INSERT from a continuous source committed multiple append snapshots on checkpoints while the job was still running, with the data readable mid-flight -- the exactly-once checkpoint-commit loop that Flink streaming ingestion relies on. Write-side extras hover behind this cell: write.distribution-mode of hash or range shuffles rows before writing (range is statistics-driven for skew, FlinkSink-only), and the Dynamic Iceberg Sink (Java API) routes each record to a table chosen at runtime, creating target tables on demand -- one stream fanning out to many tables.",
       "caveats": [
         "INSERT OVERWRITE is batch-only"
       ],
@@ -369,6 +385,10 @@
         {
           "label": "Flink writes",
           "url": "https://iceberg.apache.org/docs/latest/flink-writes/"
+        },
+        {
+          "label": "Flink Dynamic Iceberg Sink",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#flink-dynamic-iceberg-sink"
         }
       ]
     },
@@ -707,23 +727,31 @@
     },
     "flink:type-promotion:v2": {
       "level": "full",
-      "notes": "Flink supports type widening for Iceberg tables",
+      "notes": "Verified: ALTER TABLE MODIFY widened INT to BIGINT and FLOAT to DOUBLE, and an out-of-INT-range value was stored and read back. The Dynamic Sink applies the same widenings automatically at runtime when the incoming record schema is wider than the table's (Java API).",
       "caveats": [],
       "links": [
         {
-          "label": "Flink writes - type widening",
-          "url": "https://iceberg.apache.org/docs/nightly/flink-writes/#dynamic-routing-configuration"
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        },
+        {
+          "label": "Flink Dynamic Iceberg Sink",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#flink-dynamic-iceberg-sink"
         }
       ]
     },
     "flink:type-promotion:v3": {
       "level": "full",
-      "notes": "Flink supports type widening for Iceberg V3 tables",
+      "notes": "Verified: ALTER TABLE MODIFY widened INT to BIGINT and FLOAT to DOUBLE, and an out-of-INT-range value was stored and read back. The Dynamic Sink applies the same widenings automatically at runtime when the incoming record schema is wider than the table's (Java API).",
       "caveats": [],
       "links": [
         {
-          "label": "Flink writes - type widening",
-          "url": "https://iceberg.apache.org/docs/nightly/flink-writes/#dynamic-routing-configuration"
+          "label": "Flink DDL",
+          "url": "https://iceberg.apache.org/docs/latest/flink-ddl/"
+        },
+        {
+          "label": "Flink Dynamic Iceberg Sink",
+          "url": "https://iceberg.apache.org/docs/latest/flink-writes/#flink-dynamic-iceberg-sink"
         }
       ]
     },

--- a/tests/docker/docker-compose.flink.yml
+++ b/tests/docker/docker-compose.flink.yml
@@ -1,0 +1,75 @@
+# Dockerized Flink cluster used by tests/flink_feature_tests.py.
+#
+# Runs a standalone Flink 2.3 cluster (one JobManager, one TaskManager) from an
+# image that already carries the Iceberg Flink runtime jars (see flink/Dockerfile).
+# The harness drives it with the SQL client inside the JobManager container:
+#
+#   docker compose -f docker-compose.flink.yml exec -T jobmanager \
+#     /opt/flink/bin/sql-client.sh embedded -f /work/<script>.sql
+#
+# Catalog connectivity: the cluster talks to the Lakekeeper REST catalog and
+# MinIO from tests/docker/docker-compose.lakekeeper.yml over the host's own IP
+# (published ports) rather than over a shared compose network. That is required,
+# not just convenient -- Lakekeeper returns a storage endpoint on loadTable that
+# overrides the client's own, and the warehouse advertises the host IP so that
+# both host-side engines and containers resolve the same address. See the note at
+# the top of docker-compose.lakekeeper.yml.
+#
+# Bring it up with tests/docker/start-flink.sh (which detects the host IP), and
+# tear it down with tests/docker/stop-flink.sh.
+
+name: iceberg-promise-flink
+
+services:
+  jobmanager:
+    build:
+      context: ./flink
+      args:
+        FLINK_IMAGE: ${FLINK_IMAGE:-flink:2.3.0-scala_2.12-java17}
+        ICEBERG_VERSION: ${ICEBERG_VERSION:-1.11.0}
+        ICEBERG_FLINK_MAJOR: ${ICEBERG_FLINK_MAJOR:-2.1}
+    image: iceberg-promise-flink:${FLINK_VERSION:-2.3.0}-iceberg${ICEBERG_VERSION:-1.11.0}
+    command: jobmanager
+    ports:
+      - "8081:8081"
+    environment:
+      # rest.address is what the in-container SQL client dials; rest.bind-address
+      # keeps the published port reachable from the host.
+      FLINK_PROPERTIES: |
+        jobmanager.rpc.address: jobmanager
+        rest.address: jobmanager
+        rest.bind-address: 0.0.0.0
+        taskmanager.numberOfTaskSlots: 4
+        parallelism.default: 1
+        execution.checkpointing.interval: 5s
+        execution.checkpointing.min-pause: 1s
+        table.exec.sink.upsert-materialize: NONE
+    volumes:
+      - ./flink-work:/work
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8081/overview || exit 1"]
+      interval: 3s
+      timeout: 10s
+      retries: 30
+      start_period: 10s
+
+  taskmanager:
+    image: iceberg-promise-flink:${FLINK_VERSION:-2.3.0}-iceberg${ICEBERG_VERSION:-1.11.0}
+    command: taskmanager
+    depends_on:
+      jobmanager:
+        condition: service_started
+    environment:
+      FLINK_PROPERTIES: |
+        jobmanager.rpc.address: jobmanager
+        taskmanager.numberOfTaskSlots: 4
+        parallelism.default: 1
+        execution.checkpointing.interval: 5s
+        execution.checkpointing.min-pause: 1s
+        table.exec.sink.upsert-materialize: NONE
+    volumes:
+      - ./flink-work:/work
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/tests/docker/docker-compose.lakekeeper.yml
+++ b/tests/docker/docker-compose.lakekeeper.yml
@@ -44,6 +44,11 @@ services:
       interval: 2s
       timeout: 10s
       retries: 20
+    # Published so engines outside this compose project can use Postgres
+    # directly: the Flink suite needs it for the JDBC catalog test and for the
+    # jdbc maintenance lock (Iceberg 1.11 accepts only jdbc or zookeeper there).
+    ports:
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
@@ -104,8 +109,14 @@ services:
       LAKEKEEPER__PG_DATABASE_URL_READ: "postgresql://postgres:postgres@db:5432/postgres"
       LAKEKEEPER__PG_DATABASE_URL_WRITE: "postgresql://postgres:postgres@db:5432/postgres"
       LAKEKEEPER__AUTHZ_BACKEND: "allowall"
-      # Clients run on the host, so advertise the published address.
-      LAKEKEEPER__BASE_URI: "http://localhost:8181"
+      # Lakekeeper returns this address in the "overrides.uri" of GET /v1/config,
+      # and Iceberg's REST client applies that override in place of the URI the
+      # client was configured with. It therefore has to be reachable from every
+      # client, exactly like the warehouse's S3 endpoint below. "localhost" only
+      # works for host-side engines -- a containerized engine (see
+      # docker-compose.flink.yml) would resolve it to itself and get connection
+      # refused -- so advertise the host's own IP, which both reach.
+      LAKEKEEPER__BASE_URI: "http://${LAKEKEEPER_S3_HOST:-localhost}:8181"
       RUST_LOG: "info"
     ports:
       - "8181:8181"

--- a/tests/docker/flink/Dockerfile
+++ b/tests/docker/flink/Dockerfile
@@ -1,0 +1,56 @@
+# Flink image preloaded with the Iceberg Flink runtime and the jars it needs.
+#
+# Version pinning rationale (checked 2026-07):
+#   - Flink 2.3.0 is the latest Flink release.
+#   - Iceberg 1.11.0 is the latest Iceberg release and the first release where
+#     the V3 spec is production-ready.
+#   - Iceberg publishes no Flink 2.2/2.3 runtime yet, so the latest published
+#     runtime (iceberg-flink-runtime-2.1) is used against the 2.3 engine.
+#     ICEBERG_FLINK_MAJOR is the runtime's Flink minor and intentionally
+#     differs from the engine version.
+ARG FLINK_IMAGE=flink:2.3.0-scala_2.12-java17
+FROM ${FLINK_IMAGE}
+
+ARG ICEBERG_VERSION=1.11.0
+ARG ICEBERG_FLINK_MAJOR=2.1
+# Hadoop 3.x client jars, NOT flink-shaded-hadoop-2-uber. The shaded 2.8.3 uber
+# jar is Hadoop 2.8, and Iceberg 1.11's Hadoop file IO calls
+# FileSystem.openFile(), which only exists from Hadoop 3.3 on: with the old jar
+# the Hadoop and JDBC catalogs write fine and then fail every read with
+# NoSuchMethodError. (The REST catalog hides the problem because it goes through
+# S3FileIO instead of the Hadoop FileSystem API.)
+ARG HADOOP_VERSION=3.4.1
+ARG POSTGRES_JDBC_VERSION=42.7.4
+
+USER root
+
+RUN set -eux; \
+    if ! command -v curl >/dev/null 2>&1; then \
+      apt-get update; \
+      apt-get install -y --no-install-recommends curl ca-certificates; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Iceberg Flink runtime plus the AWS bundle that provides S3FileIO, so Iceberg
+# reads/writes data files on S3 (MinIO). Iceberg's Flink catalog loader
+# instantiates org.apache.hadoop.conf.Configuration regardless of catalog type,
+# so Hadoop classes must also be on the classpath. The Postgres driver backs the
+# JDBC catalog test against the stack's Postgres instance.
+RUN set -eux; \
+    APACHE=https://repo1.maven.org/maven2/org/apache; \
+    curl -fsSL -o /opt/flink/lib/iceberg-flink-runtime-${ICEBERG_FLINK_MAJOR}-${ICEBERG_VERSION}.jar \
+      "${APACHE}/iceberg/iceberg-flink-runtime-${ICEBERG_FLINK_MAJOR}/${ICEBERG_VERSION}/iceberg-flink-runtime-${ICEBERG_FLINK_MAJOR}-${ICEBERG_VERSION}.jar"; \
+    curl -fsSL -o /opt/flink/lib/iceberg-aws-bundle-${ICEBERG_VERSION}.jar \
+      "${APACHE}/iceberg/iceberg-aws-bundle/${ICEBERG_VERSION}/iceberg-aws-bundle-${ICEBERG_VERSION}.jar"; \
+    curl -fsSL -o /opt/flink/lib/hadoop-client-api-${HADOOP_VERSION}.jar \
+      "${APACHE}/hadoop/hadoop-client-api/${HADOOP_VERSION}/hadoop-client-api-${HADOOP_VERSION}.jar"; \
+    curl -fsSL -o /opt/flink/lib/hadoop-client-runtime-${HADOOP_VERSION}.jar \
+      "${APACHE}/hadoop/hadoop-client-runtime/${HADOOP_VERSION}/hadoop-client-runtime-${HADOOP_VERSION}.jar"; \
+    curl -fsSL -o /opt/flink/lib/postgresql-${POSTGRES_JDBC_VERSION}.jar \
+      "https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}/postgresql-${POSTGRES_JDBC_VERSION}.jar"
+
+# SQL scripts written by the test harness land here via a bind mount, and the
+# Hadoop-catalog test needs a writable warehouse directory.
+RUN mkdir -p /work /tmp/hadoop-warehouse && chown -R flink:flink /work /tmp/hadoop-warehouse
+
+USER flink

--- a/tests/docker/host-ip.sh
+++ b/tests/docker/host-ip.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Shared helper: detect the address of this host that both containers and
+# host-side processes can use to reach published ports.
+#
+# Why this exists: Iceberg's Java REST client lets the storage config the
+# catalog returns on loadTable override the client's own, so every engine ends
+# up using whatever S3 endpoint the warehouse advertises. A compose-internal
+# name like http://minio:9000 is therefore unusable, because host-side engines
+# cannot resolve it. The host's own IP works from both sides -- containers reach
+# it through the published port, and the host reaches itself -- with no
+# /etc/hosts entry and no root access.
+#
+# Source this file and call detect_host_ip.
+
+detect_host_ip() {
+  local ip=""
+  if command -v ipconfig >/dev/null 2>&1; then
+    for iface in en0 en1 en2 en3; do
+      ip="$(ipconfig getifaddr "${iface}" 2>/dev/null || true)"
+      [[ -n "${ip}" ]] && break
+    done
+  fi
+  if [[ -z "${ip}" ]]; then
+    ip="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+  fi
+  if [[ -z "${ip}" ]]; then
+    # No traffic is sent; this just asks the kernel which local address would
+    # be used to reach an external host.
+    ip="$(python3 -c 'import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try:
+    s.connect(("8.8.8.8", 80))
+    print(s.getsockname()[0])
+finally:
+    s.close()' 2>/dev/null || true)"
+  fi
+  printf '%s' "${ip}"
+}

--- a/tests/docker/start-flink.sh
+++ b/tests/docker/start-flink.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Build and start the Dockerized Flink cluster used by
+# tests/flink_feature_tests.py, then wait until a TaskManager has registered so
+# the SQL client can actually run jobs.
+#
+# Requires the Lakekeeper + MinIO stack to be up first:
+#   tests/docker/start-lakekeeper.sh
+#   tests/docker/start-flink.sh
+#   python tests/flink_feature_tests.py
+#
+# Environment overrides (all optional):
+#   FLINK_IMAGE            base Flink image        (default: flink:2.3.0-scala_2.12-java17)
+#   FLINK_VERSION          Flink engine version    (default: 2.3.0)
+#   ICEBERG_VERSION        Iceberg version         (default: 1.11.0)
+#   ICEBERG_FLINK_MAJOR    Iceberg runtime's Flink minor (default: 2.1)
+#   FLINK_HOST_IP          host address containers use to reach the catalog/MinIO
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.flink.yml"
+# shellcheck source=tests/docker/host-ip.sh
+source "${SCRIPT_DIR}/host-ip.sh"
+
+export FLINK_IMAGE="${FLINK_IMAGE:-flink:2.3.0-scala_2.12-java17}"
+export FLINK_VERSION="${FLINK_VERSION:-2.3.0}"
+export ICEBERG_VERSION="${ICEBERG_VERSION:-1.11.0}"
+export ICEBERG_FLINK_MAJOR="${ICEBERG_FLINK_MAJOR:-2.1}"
+
+FLINK_HOST_IP="${FLINK_HOST_IP:-${LAKEKEEPER_S3_HOST:-$(detect_host_ip)}}"
+if [[ -z "${FLINK_HOST_IP}" ]]; then
+  echo "[flink] could not determine this host's IP address; set FLINK_HOST_IP" >&2
+  exit 1
+fi
+
+# The harness hands SQL scripts to the cluster through this bind mount.
+mkdir -p "${SCRIPT_DIR}/flink-work"
+
+echo "[flink] building image (Flink ${FLINK_VERSION}, Iceberg ${ICEBERG_VERSION}, runtime ${ICEBERG_FLINK_MAJOR})"
+docker compose -f "${COMPOSE_FILE}" build
+
+echo "[flink] starting cluster"
+docker compose -f "${COMPOSE_FILE}" up -d
+
+wait_for_slots() {
+  local overview slots
+  for _ in $(seq 1 60); do
+    overview="$(curl -sf http://127.0.0.1:8081/overview 2>/dev/null || true)"
+    if [[ -n "${overview}" ]]; then
+      slots="$(printf '%s' "${overview}" \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("slots-total", 0))' 2>/dev/null || echo 0)"
+      if [[ "${slots}" -gt 0 ]]; then
+        echo "[flink] cluster ready (${slots} task slots)"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "[flink] timed out waiting for a TaskManager to register" >&2
+  docker compose -f "${COMPOSE_FILE}" logs --tail 100 >&2 || true
+  return 1
+}
+
+wait_for_slots
+
+cat <<EOF
+[flink] cluster is up. Run the feature tests with:
+
+  export ICEBERG_REST_URI=http://${FLINK_HOST_IP}:8181/catalog
+  export ICEBERG_S3_ENDPOINT=http://${FLINK_HOST_IP}:9000
+  python tests/flink_feature_tests.py
+
+(tests/flink_feature_tests.py detects the Docker cluster automatically and
+falls back to these same defaults.)
+EOF

--- a/tests/docker/start-lakekeeper.sh
+++ b/tests/docker/start-lakekeeper.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.lakekeeper.yml"
+# shellcheck source=tests/docker/host-ip.sh
+source "${SCRIPT_DIR}/host-ip.sh"
 
 export LAKEKEEPER_WAREHOUSE="${LAKEKEEPER_WAREHOUSE:-demo}"
 export LAKEKEEPER_BUCKET="${LAKEKEEPER_BUCKET:-warehouse}"
@@ -28,39 +30,9 @@ export LAKEKEEPER_S3_SECRET="${LAKEKEEPER_S3_SECRET:-minio12345}"
 export LAKEKEEPER_S3_REGION="${LAKEKEEPER_S3_REGION:-us-east-1}"
 LAKEKEEPER_URI="${LAKEKEEPER_URI:-http://127.0.0.1:8181}"
 
-# ---------------------------------------------------------------------------
-# The warehouse must advertise an S3 endpoint that both the Lakekeeper container
-# and host-side engines can reach, because Iceberg's Java REST client applies
-# the storage config the server returns on loadTable over the client's own.
-# A compose-internal name (http://minio:9000) fails on the host with
-# UnknownHostException, so use the host's own IP: containers reach it through
-# MinIO's published port, and the host reaches itself. No /etc/hosts entry and
-# no root access required.
-# ---------------------------------------------------------------------------
-detect_host_ip() {
-  local ip=""
-  if command -v ipconfig >/dev/null 2>&1; then
-    for iface in en0 en1 en2 en3; do
-      ip="$(ipconfig getifaddr "${iface}" 2>/dev/null || true)"
-      [[ -n "${ip}" ]] && break
-    done
-  fi
-  if [[ -z "${ip}" ]]; then
-    ip="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
-  fi
-  if [[ -z "${ip}" ]]; then
-    # No traffic is sent; this just asks the kernel which local address would
-    # be used to reach an external host.
-    ip="$(python3 -c 'import socket
-s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-try:
-    s.connect(("8.8.8.8", 80))
-    print(s.getsockname()[0])
-finally:
-    s.close()' 2>/dev/null || true)"
-  fi
-  printf '%s' "${ip}"
-}
+# detect_host_ip comes from host-ip.sh, which explains why the host's own IP is
+# the only address that works for both containers and host-side engines. It is
+# used here for the warehouse's S3 endpoint and for Lakekeeper's BASE_URI.
 
 wait_for_job() {
   local service="$1" cid status exit_code

--- a/tests/docker/stop-flink.sh
+++ b/tests/docker/stop-flink.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Tear down the Dockerized Flink cluster started by start-flink.sh.
+#
+# Usage:
+#   tests/docker/stop-flink.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.flink.yml"
+
+echo "[flink] stopping cluster"
+docker compose -f "${COMPOSE_FILE}" down --remove-orphans --volumes || true
+rm -rf "${SCRIPT_DIR}/flink-work"

--- a/tests/flink_feature_tests.py
+++ b/tests/flink_feature_tests.py
@@ -523,12 +523,62 @@ def test_read_support(version: str) -> TestResult:
     if not ok:
         r.result = "error"
         r.details = _error_reason(out)
-    elif _marker(out, "MARKALL=3") and _marker(out, "MARKPRED=2") and _marker(out, "MARKPROJ=b"):
-        r.result = "pass"
-        r.details = "Read 3 rows; predicate filter returned 2; column projection correct"
-    else:
+        return r
+    if not (_marker(out, "MARKALL=3") and _marker(out, "MARKPRED=2") and _marker(out, "MARKPROJ=b")):
         r.result = "fail"
         r.details = f"Unexpected read results: {_marker_values(out, 'MARKALL')} {_marker_values(out, 'MARKPRED')}"
+        return r
+
+    # Streaming is what Flink is for, so batch reads alone are weak evidence.
+    # Verify the continuous read path: an iceberg-to-iceberg tail with a
+    # monitor-interval must deliver the initial snapshot AND rows committed to the
+    # source after the job started.
+    src, tgt = _unique("ssrc"), _unique("stgt")
+    ok_s, _ = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {src} (id BIGINT, val STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"CREATE TABLE {tgt} (id BIGINT, val STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {src} VALUES (1,'a'),(2,'b')",
+    ])
+    job_id = None
+    late_arrived = False
+    if ok_s:
+        ok_j, _, job_id = _submit_streaming(
+            _prelude(version, streaming=True, dml_sync=False) + [
+                f"INSERT INTO {tgt} SELECT id, val FROM {src} "
+                f"/*+ OPTIONS('streaming'='true','monitor-interval'='2s') */",
+            ])
+        if ok_j and job_id:
+            try:
+                time.sleep(10)
+                _run_sql(_prelude(version) + [f"INSERT INTO {src} VALUES (3,'late')"])
+                for _ in range(9):
+                    time.sleep(10)
+                    ok_p, out_p = _run_sql(_prelude(version) + [
+                        f"SELECT CONCAT('MARKT=', CAST(id AS STRING), ':', val) AS m "
+                        f"FROM {tgt} ORDER BY id",
+                    ])
+                    if ok_p and "3:late" in _marker_values(out_p, "MARKT"):
+                        late_arrived = True
+                        break
+            finally:
+                _cancel_job(job_id)
+    _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {src}",
+                                  f"DROP TABLE IF EXISTS {tgt}"])
+
+    if late_arrived:
+        r.result = "pass"
+        r.details = (
+            "Batch: read 3 rows with correct predicate filtering and projection. "
+            "Streaming: a continuous read (streaming=true, monitor-interval) delivered "
+            "the initial snapshot and a row committed to the source AFTER the job "
+            "started, into a second Iceberg table"
+        )
+    else:
+        r.result = "fail"
+        r.details = (
+            "Batch reads verified, but the continuous streaming read did not deliver a "
+            "row committed after the job started"
+        )
     return r
 
 
@@ -548,15 +598,64 @@ def test_write_insert(version: str) -> TestResult:
     if not ok:
         r.result = "error"
         r.details = _error_reason(out)
-    elif _marker(out, "MARKAPP=3") and _marker(out, "MARKOVW=1"):
-        r.result = "pass"
-        r.details = "INSERT INTO appended across 2 commits (3 rows); INSERT OVERWRITE replaced them (1 row)"
-    elif _marker(out, "MARKAPP=3"):
-        r.result = "pass"
-        r.details = f"INSERT INTO verified; INSERT OVERWRITE gave {_marker_values(out, 'MARKOVW')}"
-    else:
+        return r
+    if not _marker(out, "MARKAPP=3"):
         r.result = "fail"
         r.details = f"Unexpected counts: append={_marker_values(out, 'MARKAPP')}"
+        return r
+    batch_detail = (
+        "Batch: INSERT INTO appended across 2 commits (3 rows)"
+        + ("; INSERT OVERWRITE replaced them (1 row)" if _marker(out, "MARKOVW=1")
+           else f"; INSERT OVERWRITE gave {_marker_values(out, 'MARKOVW')}")
+    )
+
+    # Streaming writes are Flink's primary use, and their contract differs from a
+    # bounded insert: commits are driven by checkpoints while the job keeps
+    # running. Assert that an unbounded INSERT produces MULTIPLE append snapshots
+    # and that the data is readable mid-flight, before the job ever finishes.
+    stbl = _unique("swrite")
+    src = "default_catalog.default_database." + _unique("sgen")
+    ok_j, out_j, job_id = _submit_streaming(
+        _prelude(version, streaming=True, dml_sync=False) + [
+            f"CREATE TABLE {stbl} (id BIGINT, val STRING) WITH ('format-version'='{_fmt(version)}')",
+            f"""CREATE TEMPORARY TABLE {src} (id BIGINT, val STRING) WITH (
+                'connector'='datagen', 'rows-per-second'='10', 'fields.val.length'='8')""",
+            f"INSERT INTO {stbl} SELECT id, val FROM {src}",
+        ])
+    commits, mid_rows = 0, 0
+    if ok_j and job_id:
+        try:
+            for _ in range(9):
+                time.sleep(10)
+                ok_p, out_p = _run_sql(_prelude(version) + [
+                    f"SELECT CONCAT('MARKSN=', CAST(COUNT(*) AS STRING)) AS m FROM `{stbl}$snapshots`",
+                    f"SELECT CONCAT('MARKCNT=', CAST(COUNT(*) AS STRING)) AS m FROM {stbl}",
+                ])
+                if ok_p:
+                    sn = _marker_values(out_p, "MARKSN")
+                    cnt = _marker_values(out_p, "MARKCNT")
+                    commits = int(sn[0]) if sn else 0
+                    mid_rows = int(cnt[0]) if cnt else 0
+                    if commits >= 3 and mid_rows > 0:
+                        break
+        finally:
+            _cancel_job(job_id)
+    _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {stbl}"])
+
+    if commits >= 3 and mid_rows > 0:
+        r.result = "pass"
+        r.details = (
+            f"{batch_detail}. Streaming: an unbounded INSERT committed {commits} append "
+            f"snapshots on checkpoints while the job was still running, with {mid_rows} "
+            "rows already readable mid-flight (exactly-once checkpoint commit loop)"
+        )
+    else:
+        r.result = "fail"
+        r.details = (
+            f"{batch_detail}. Streaming write did not demonstrate checkpoint commits: "
+            f"snapshots={commits}, rows readable mid-job={mid_rows}"
+            + ("" if ok_j and job_id else f" ({_error_reason(out_j, 120)})")
+        )
     return r
 
 
@@ -610,9 +709,14 @@ def _upsert_delete_evidence(version: str, use_v2_sink: bool, same_batch: bool = 
       True  - both versions of the key arrive in one statement, so the superseded
               row is deleted by position within the file being written. On a V3
               table that position delete is written as a deletion vector.
+
+    The inserts run in the STREAMING runtime, since upsert exists for streaming
+    CDC pipelines; the verification SELECTs run in the same session after
+    switching back to batch. Bounded VALUES sources work under dml-sync in
+    either runtime, so the session stays synchronous throughout.
     """
     tbl = _unique("ups")
-    stmts = _prelude(version)
+    stmts = _prelude(version, streaming=True)
     if use_v2_sink:
         stmts.append("SET 'table.exec.iceberg.use-v2-sink' = 'true'")
     stmts.append(
@@ -625,6 +729,7 @@ def _upsert_delete_evidence(version: str, use_v2_sink: bool, same_batch: bool = 
         stmts.append(f"INSERT INTO {tbl} VALUES (1,'first'),(2,'second')")
         stmts.append(f"INSERT INTO {tbl} VALUES (1,'updated')")
     stmts += [
+        "SET 'execution.runtime-mode' = 'batch'",
         f"SELECT CONCAT('MARKROW=', CAST(id AS STRING), ':', name) AS m FROM {tbl} ORDER BY id",
         f"SELECT CONCAT('MARKDEL=', CAST(content AS STRING), ':', file_format) AS m FROM `{tbl}$delete_files`",
         f"DROP TABLE {tbl}",
@@ -663,18 +768,36 @@ def test_merge_on_read(version: str) -> TestResult:
     if not ok:
         r.result = "error"
         r.details = _error_reason(out)
-    elif deletes and "1:updated" in rows:
-        r.result = "pass"
-        r.details = (
-            "Write produced delete files that the reader merged at scan time "
-            f"(deletes={deletes}, rows={rows})"
-        )
-    elif "1:updated" in rows:
-        r.result = "fail"
-        r.details = f"Row was replaced but no delete files were written: rows={rows}"
-    else:
+        return r
+    if not (deletes and "1:updated" in rows):
         r.result = "fail"
         r.details = f"Merge-on-read not demonstrated: rows={rows}, deletes={deletes}"
+        return r
+
+    # Upsert is not just capable of MoR -- it is MoR-only. Prove it by setting all
+    # copy-on-write modes on the table: the writer must ignore them and still
+    # produce delete files.
+    tbl = _unique("morcow")
+    ok2, out2 = _run_sql(_prelude(version) + [
+        f"""CREATE TABLE {tbl} (id BIGINT, val STRING, PRIMARY KEY (id) NOT ENFORCED)
+            WITH ('format-version'='{_fmt(version)}', 'write.upsert.enabled'='true',
+                  'write.delete.mode'='copy-on-write', 'write.update.mode'='copy-on-write',
+                  'write.merge.mode'='copy-on-write')""",
+        f"INSERT INTO {tbl} VALUES (1,'first'),(2,'second')",
+        f"INSERT INTO {tbl} VALUES (1,'updated')",
+        f"SELECT CONCAT('MARKDEL=', CAST(content AS STRING), ':', file_format) AS m FROM `{tbl}$delete_files`",
+        f"DROP TABLE {tbl}",
+    ])
+    cow_ignored = ok2 and bool(_marker_values(out2, "MARKDEL"))
+    r.result = "pass"
+    r.details = (
+        "Upsert produced delete files that the reader merged at scan time "
+        f"(deletes={deletes}, rows={rows})."
+        + (" Merge-on-read is also the ONLY write path for upsert: with all "
+           "write.*.mode properties set to copy-on-write the writer still emitted "
+           f"delete files ({_marker_values(out2, 'MARKDEL')}), ignoring the setting"
+           if cow_ignored else "")
+    )
     return r
 
 

--- a/tests/flink_feature_tests.py
+++ b/tests/flink_feature_tests.py
@@ -426,6 +426,36 @@ def _rest_evolve_spec(table: str, namespace: str = "test_db") -> bool:
         return False
 
 
+def _rest_set_tags(table: str, tags: dict, namespace: str = "test_db") -> bool:
+    """Create tags on existing snapshots through the catalog.
+
+    Flink has no ref DDL, so tags for the tag-read and tag-to-tag scan tests have
+    to come from the catalog itself.
+    """
+    import urllib.request
+    try:
+        base = REST_URI.rstrip("/")
+        md = _rest_table_metadata(table, namespace)
+        body = {
+            "requirements": [{"type": "assert-table-uuid", "uuid": md["table-uuid"]}],
+            "updates": [
+                {"action": "set-snapshot-ref", "ref-name": name,
+                 "type": "tag", "snapshot-id": snap_id}
+                for name, snap_id in tags.items()
+            ],
+        }
+        req = urllib.request.Request(
+            f"{base}/v1/{_rest_prefix()}/namespaces/{namespace}/tables/{table}",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            json.load(resp)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _rest_create_transform_partitioned(version: str, namespace: str = "test_db"):
     """Create a day(ts)-partitioned table straight through the REST catalog API.
 
@@ -1147,17 +1177,43 @@ def test_branching_tagging(version: str) -> TestResult:
     ok_ddl, out_ddl = _run_sql(_prelude(version) + [
         f"ALTER TABLE {tbl} CREATE BRANCH testbranch",
     ])
+
+    # Flink cannot create refs, so make a tag through the catalog and verify the
+    # tag read and tag-to-tag incremental scan hints against it.
+    tag_ok = False
+    ok_s, out_s = _run_sql(_prelude(version) + [
+        f"INSERT INTO {tbl} VALUES (2,'b')",
+        f"SELECT CONCAT('MARKSNAP=', CAST(snapshot_id AS STRING)) AS m "
+        f"FROM `{tbl}$snapshots` ORDER BY committed_at",
+    ])
+    snaps = _marker_values(out_s, "MARKSNAP")
+    if ok_s and len(snaps) >= 2 and _rest_set_tags(tbl, {"tag1": int(snaps[0]), "tag2": int(snaps[1])}):
+        ok_t, out_t = _run_sql(_prelude(version) + [
+            f"SELECT CONCAT('MARKTAG=', CAST(COUNT(*) AS STRING)) AS m "
+            f"FROM {tbl} /*+ OPTIONS('tag'='tag1') */",
+            f"SELECT CONCAT('MARKT2T=', val) AS m "
+            f"FROM {tbl} /*+ OPTIONS('start-tag'='tag1','end-tag'='tag2') */",
+        ])
+        tag_ok = ok_t and _marker(out_t, "MARKTAG=1") \
+            and _marker_values(out_t, "MARKT2T") == ["b"]
     _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
 
     if read_ok and ok_ddl:
         r.result = "pass"
         r.details = "Branch reads via the branch hint work, and CREATE BRANCH DDL is supported"
+    elif read_ok and tag_ok:
+        r.result = "pass"
+        r.details = (
+            "Branch reads via the branch hint, tag reads via the tag hint, and tag-to-tag "
+            "incremental scans (start-tag/end-tag) all work against refs created through "
+            f"the catalog; Flink cannot create refs via DDL ({_error_reason(out_ddl, 80)})"
+        )
     elif read_ok:
         r.result = "pass"
         r.details = (
             f"Reading a branch via /*+ OPTIONS('branch'='main') */ works and refs are "
-            f"listable ({_marker_values(out, 'MARKREF')}), but Flink cannot create refs "
-            f"via DDL: {_error_reason(out_ddl, 90)}"
+            f"listable ({_marker_values(out, 'MARKREF')}); tag hints could not be verified "
+            "and Flink cannot create refs via DDL"
         )
     else:
         r.result = "fail"
@@ -1417,17 +1473,36 @@ def test_nanosecond_timestamps(version: str) -> TestResult:
         f"INSERT INTO {tbl} VALUES (1, TIMESTAMP '2026-01-01 12:00:00.123456789')",
         f"""SELECT CONCAT('MARKNANO=', CASE WHEN ts = TIMESTAMP '2026-01-01 12:00:00.123456789'
              THEN 'EXACT' ELSE 'LOSSY' END) AS m FROM {tbl}""",
-        f"DROP TABLE {tbl}",
     ])
+    # The round-trip alone could in principle be satisfied by Flink comparing two
+    # equally-truncated values; confirm the column is genuinely the V3 timestamp_ns
+    # type by reading the Iceberg schema from the catalog.
+    meta = _rest_table_metadata(tbl)
+    stored = ""
+    if meta:
+        for f in meta.get("schemas", [{}])[-1].get("fields", []):
+            if f.get("name") == "ts":
+                stored = str(f.get("type"))
+    _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
+
     if not ok:
         r.result = "fail"
         r.details = f"TIMESTAMP(9) not usable on a V3 table: {_error_reason(out, 150)}"
+    elif _marker(out, "MARKNANO=EXACT") and stored == "timestamp_ns":
+        r.result = "pass"
+        r.details = (
+            "TIMESTAMP(9) maps to the Iceberg V3 timestamp_ns type (confirmed in the table "
+            "schema) and a nanosecond-precision value round-trips exactly"
+        )
     elif _marker(out, "MARKNANO=EXACT"):
         r.result = "pass"
-        r.details = "TIMESTAMP(9) round-tripped with full nanosecond precision preserved"
+        r.details = (
+            f"Nanosecond value round-tripped exactly, but the stored Iceberg type reads as "
+            f"'{stored or 'unavailable'}' rather than timestamp_ns"
+        )
     else:
         r.result = "fail"
-        r.details = "TIMESTAMP(9) accepted but the value lost precision on round-trip"
+        r.details = f"TIMESTAMP(9) accepted but the value lost precision (stored type: {stored})"
     return r
 
 

--- a/tests/flink_feature_tests.py
+++ b/tests/flink_feature_tests.py
@@ -45,6 +45,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -98,6 +99,11 @@ JDBC_PASSWORD = os.environ.get("ICEBERG_JDBC_PASSWORD", "postgres")
 HADOOP_WAREHOUSE = os.environ.get("ICEBERG_HADOOP_WAREHOUSE", "file:///work/hadoop-warehouse")
 
 VERSIONS = ["v2", "v3"]
+
+# How long to wait for in-job compaction to produce a rewrite commit. Sized off
+# the 5s checkpoint interval configured in docker-compose.flink.yml: a rewrite
+# was observed within ~90s locally.
+MAINTENANCE_POLL_SECONDS = int(os.environ.get("FLINK_MAINTENANCE_POLL_SECONDS", "180"))
 
 
 def _detect_mode() -> str:
@@ -198,6 +204,33 @@ def _run_sql(statements: list, timeout: int = 240) -> tuple:
         return False, str(e)
 
 
+def _submit_streaming(statements: list, timeout: int = 240) -> tuple:
+    """Submit an unbounded streaming job and return (ok, out, job_id).
+
+    Deliberately does NOT set table.dml-sync: an unbounded INSERT would never
+    return. The SQL client submits the job detached and prints its Job ID, which
+    the caller polls against and must cancel afterwards.
+    """
+    ok, out = _run_sql(statements, timeout=timeout)
+    m = re.search(r"Job ID:\s*([0-9a-f]{32})", out)
+    return ok, out, (m.group(1) if m else None)
+
+
+def _cancel_job(job_id: str) -> None:
+    """Cancel a running Flink job so it cannot leak into later tests."""
+    if not job_id:
+        return
+    try:
+        if MODE == "docker":
+            cmd = ["docker", "compose", "-f", COMPOSE_FILE, "exec", "-T", "jobmanager",
+                   "/opt/flink/bin/flink", "cancel", job_id]
+        else:
+            cmd = [os.path.join(FLINK_HOME, "bin", "flink"), "cancel", job_id]
+        subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _marker(out: str, expected: str) -> bool:
     """True when a MARK... token appears in the client's tableau output.
 
@@ -240,15 +273,18 @@ def _error_reason(out: str, limit: int = 220) -> str:
     return flat[:limit]
 
 
-def _prelude(version: str = "v3", catalog: str = "rest", streaming: bool = False) -> list:
-    """Session setup: result mode, synchronous DML, and the requested catalog.
+def _prelude(version: str = "v3", catalog: str = "rest", streaming: bool = False,
+             dml_sync: bool = True) -> list:
+    """Session setup: result mode, DML sync mode, and the requested catalog.
 
-    table.dml-sync is essential: without it the SQL client submits INSERT jobs
-    detached and a following SELECT races the write, silently reading zero rows.
+    table.dml-sync is essential for bounded work: without it the SQL client
+    submits INSERT jobs detached and a following SELECT races the write, silently
+    reading zero rows. It must be OFF for an unbounded streaming INSERT, which
+    would otherwise never return and hang the client until its timeout.
     """
     stmts = [
         "SET 'sql-client.execution.result-mode' = 'tableau'",
-        "SET 'table.dml-sync' = 'true'",
+        f"SET 'table.dml-sync' = '{str(dml_sync).lower()}'",
         "SET 'table.dynamic-table-options.enabled' = 'true'",
         f"SET 'execution.runtime-mode' = '{'streaming' if streaming else 'batch'}'",
     ]
@@ -755,42 +791,75 @@ def test_time_travel(version: str) -> TestResult:
 def test_table_maintenance(version: str) -> TestResult:
     r = TestResult("table-maintenance", "Table Maintenance", version)
     tbl = _unique("maint")
-    # Flink's maintenance runs inside the job via IcebergSink post-commit hooks,
-    # configured with flink-maintenance.* options (Iceberg 1.11 accepts only jdbc
-    # or zookeeper as the SQL lock type). A compaction commit shows up as a
-    # "replace" snapshot operation.
-    ok, out = _run_sql(_prelude(version, streaming=False) + [
+    # Flink is the only engine that runs Iceberg maintenance inside its own job:
+    # IcebergSink post-commit tasks, configured from SQL with flink-maintenance.*
+    # options (Iceberg 1.11 accepts only jdbc or zookeeper for the SQL lock type).
+    #
+    # It has to be a STREAMING job. Scheduling counts commits, and a bounded batch
+    # INSERT produces a single commit and then the job ends, so compaction never
+    # fires. A datagen source with periodic checkpointing commits repeatedly, and a
+    # compaction shows up as a "replace" snapshot operation.
+    src = "default_catalog.default_database." + _unique("src")
+    ok, out, job_id = _submit_streaming(_prelude(version, streaming=True, dml_sync=False) + [
         "SET 'table.exec.iceberg.use-v2-sink' = 'true'",
         f"""CREATE TABLE {tbl} (id BIGINT, val STRING) WITH (
             'format-version'='{_fmt(version)}',
             'flink-maintenance.rewrite.enabled'='true',
-            'flink-maintenance.rewrite.schedule.commit-count'='1',
+            'flink-maintenance.rewrite.schedule.commit-count'='2',
             'flink-maintenance.lock.type'='jdbc',
             'flink-maintenance.lock.lock-id'='{tbl}',
             'flink-maintenance.lock.jdbc.uri'='{JDBC_URI}?user={JDBC_USER}&password={JDBC_PASSWORD}',
             'flink-maintenance.lock.jdbc.init-lock-table'='true')""",
-        f"INSERT INTO {tbl} VALUES (1,'a')",
-        f"INSERT INTO {tbl} VALUES (2,'b')",
-        f"SELECT CONCAT('MARKOP=', operation) AS m FROM `{tbl}$snapshots` ORDER BY committed_at",
-        f"SELECT CONCAT('MARKCNT=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
-        f"DROP TABLE {tbl}",
-    ], timeout=360)
-    ops = _marker_values(out, "MARKOP")
-    if ok and "replace" in ops:
-        r.result = "pass"
-        r.details = (
-            "In-job post-commit compaction ran: snapshot operations "
-            f"{ops} include a 'replace' (rewrite) commit"
-        )
-    elif ok and _marker(out, "MARKCNT=2"):
+        f"""CREATE TEMPORARY TABLE {src} (id BIGINT, val STRING) WITH (
+            'connector'='datagen', 'rows-per-second'='20', 'fields.val.length'='8')""",
+        f"INSERT INTO {tbl} SELECT id, val FROM {src}",
+    ])
+    if not ok or not job_id:
         r.result = "fail"
         r.details = (
-            f"flink-maintenance options accepted and data intact, but no rewrite commit "
-            f"appeared (operations={ops}); scheduled compaction did not trigger"
+            f"In-job maintenance not usable from SQL: {_error_reason(out, 170)}"
+            if not ok else "Streaming job was accepted but no Job ID was reported"
+        )
+        return r
+
+    ops = []
+    try:
+        # Poll until a rewrite commit appears. Checkpointing is every 5s, so a
+        # few commits accumulate quickly; give it generous headroom regardless.
+        deadline = MAINTENANCE_POLL_SECONDS
+        waited = 0
+        while waited < deadline:
+            time.sleep(15)
+            waited += 15
+            ok_p, out_p = _run_sql(_prelude(version) + [
+                f"SELECT CONCAT('MARKOP=', operation) AS m "
+                f"FROM `{tbl}$snapshots` ORDER BY committed_at",
+            ])
+            if ok_p:
+                ops = _marker_values(out_p, "MARKOP")
+                if "replace" in ops:
+                    break
+    finally:
+        _cancel_job(job_id)
+        _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
+
+    appends = ops.count("append")
+    if "replace" in ops:
+        r.result = "pass"
+        r.details = (
+            f"In-job post-commit compaction ran in a streaming job: {appends} append "
+            "commits plus a 'replace' (rewrite) snapshot, with no external scheduler "
+            "and no Spark. Configured entirely from SQL via flink-maintenance.* options"
+        )
+    elif ops:
+        r.result = "fail"
+        r.details = (
+            f"Streaming job committed {appends} snapshots but no rewrite commit appeared "
+            f"within {MAINTENANCE_POLL_SECONDS}s (operations={sorted(set(ops))})"
         )
     else:
         r.result = "fail"
-        r.details = f"In-job maintenance not usable from SQL: {_error_reason(out, 170)}"
+        r.details = "Streaming job started but no snapshots were committed"
     return r
 
 

--- a/tests/flink_feature_tests.py
+++ b/tests/flink_feature_tests.py
@@ -359,6 +359,45 @@ def _v3_only(feature_id: str, feature_name: str) -> TestResult:
     return r
 
 
+def _rest_create_transform_partitioned(version: str, namespace: str = "test_db"):
+    """Create a day(ts)-partitioned table straight through the REST catalog API.
+
+    Flink DDL cannot express transform partitioning, so a table that exercises the
+    hidden-partitioning read/write path has to be created by something else. Going
+    to the catalog's own HTTP API avoids adding an engine or library just for this.
+    Returns the table name, or None if the catalog rejected the request.
+    """
+    import urllib.error
+    import urllib.request
+    base = REST_URI.rstrip("/")
+    name = _unique("hpext")
+    try:
+        with urllib.request.urlopen(f"{base}/v1/config?warehouse={REST_WAREHOUSE}", timeout=15) as resp:
+            prefix = json.load(resp)["defaults"]["prefix"]
+        body = {
+            "name": name,
+            "schema": {"type": "struct", "schema-id": 0, "fields": [
+                {"id": 1, "name": "id", "required": False, "type": "long"},
+                {"id": 2, "name": "ts", "required": False, "type": "timestamptz"},
+            ]},
+            "partition-spec": {"spec-id": 0, "fields": [
+                {"source-id": 2, "field-id": 1000, "name": "ts_day", "transform": "day"},
+            ]},
+            "stage-create": False,
+            "properties": {"format-version": _fmt(version)},
+        }
+        req = urllib.request.Request(
+            f"{base}/v1/{prefix}/namespaces/{namespace}/tables",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            json.load(resp)
+        return name
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _external_service(feature_id: str, feature_name: str, version: str, what: str) -> TestResult:
     """Honest skip for a catalog that needs a service or credentials we lack."""
     r = TestResult(feature_id, feature_name, version)
@@ -490,22 +529,35 @@ def test_write_merge_update_delete(version: str) -> TestResult:
 # Row-level operations
 # ---------------------------------------------------------------------------
 
-def _upsert_delete_evidence(version: str, use_v2_sink: bool):
+def _upsert_delete_evidence(version: str, use_v2_sink: bool, same_batch: bool = False):
     """Run an upsert that must replace a row, and report the delete files written.
 
     Returns (ok, out, rows, delete_kinds). delete_kinds holds "<content>:<format>"
-    per delete file: content 1 = position deletes, 2 = equality deletes; a puffin
-    format means a V3 deletion vector.
+    per delete file: content 1 = position deletes, 2 = equality deletes, and a
+    puffin format on a position delete means a V3 deletion vector.
+
+    same_batch controls which delete flavour the writer produces, and the
+    distinction matters:
+      False - the duplicate key arrives in a later commit, so the writer can only
+              delete by key and emits an equality delete file.
+      True  - both versions of the key arrive in one statement, so the superseded
+              row is deleted by position within the file being written. On a V3
+              table that position delete is written as a deletion vector.
     """
     tbl = _unique("ups")
     stmts = _prelude(version)
     if use_v2_sink:
         stmts.append("SET 'table.exec.iceberg.use-v2-sink' = 'true'")
-    stmts += [
+    stmts.append(
         f"""CREATE TABLE {tbl} (id BIGINT, name STRING, PRIMARY KEY (id) NOT ENFORCED)
-            WITH ('format-version'='{_fmt(version)}', 'write.upsert.enabled'='true')""",
-        f"INSERT INTO {tbl} VALUES (1,'first'),(2,'second')",
-        f"INSERT INTO {tbl} VALUES (1,'updated')",
+            WITH ('format-version'='{_fmt(version)}', 'write.upsert.enabled'='true')"""
+    )
+    if same_batch:
+        stmts.append(f"INSERT INTO {tbl} VALUES (1,'first'),(1,'updated'),(2,'second')")
+    else:
+        stmts.append(f"INSERT INTO {tbl} VALUES (1,'first'),(2,'second')")
+        stmts.append(f"INSERT INTO {tbl} VALUES (1,'updated')")
+    stmts += [
         f"SELECT CONCAT('MARKROW=', CAST(id AS STRING), ':', name) AS m FROM {tbl} ORDER BY id",
         f"SELECT CONCAT('MARKDEL=', CAST(content AS STRING), ':', file_format) AS m FROM `{tbl}$delete_files`",
         f"DROP TABLE {tbl}",
@@ -618,38 +670,43 @@ def test_deletion_vectors(version: str) -> TestResult:
     if version == "v2":
         return _v3_only("deletion-vectors", "Deletion Vectors")
     r = TestResult("deletion-vectors", "Deletion Vectors", version)
-    # Iceberg 1.11 writes DVs from IcebergSink (the Sink V2 implementation), which
-    # is OFF by default (table.exec.iceberg.use-v2-sink=false). Test both sinks so
-    # the report distinguishes "unsupported" from "not the default".
-    ok_d, out_d, rows_d, del_d = _upsert_delete_evidence(version, use_v2_sink=False)
-    ok_v2, out_v2, rows_v2, del_v2 = _upsert_delete_evidence(version, use_v2_sink=True)
+    # Deletion vectors replace POSITION deletes, so the write has to produce a
+    # position delete to produce a DV. An upsert whose duplicate key arrives in a
+    # later commit can only delete by key and yields an equality delete file; when
+    # both versions arrive in the same statement, the superseded row is deleted by
+    # position and a V3 table records that as a puffin DV. Test the same-batch path
+    # under both sinks, and keep the cross-commit run for contrast.
+    ok_b, out_b, rows_b, del_b = _upsert_delete_evidence(version, False, same_batch=True)
+    ok_v2, out_v2, _, del_v2 = _upsert_delete_evidence(version, True, same_batch=True)
+    _, _, _, del_cross = _upsert_delete_evidence(version, False, same_batch=False)
 
-    def _has_dv(kinds):
+    def _dv(kinds):
+        # content 1 = position deletes; puffin on a position delete is a DV.
         return [k for k in kinds if "puffin" in k.lower()]
 
-    dv_default, dv_v2sink = _has_dv(del_d), _has_dv(del_v2)
-    if dv_default:
-        r.result = "pass"
-        r.details = f"Default sink wrote puffin deletion vectors: {dv_default}"
-    elif dv_v2sink:
+    dv_default, dv_sink2 = _dv(del_b), _dv(del_v2)
+    if not ok_b:
+        r.result = "error"
+        r.details = _error_reason(out_b)
+    elif dv_default and "1:updated" in rows_b:
         r.result = "pass"
         r.details = (
-            "Deletion vectors written only with the Sink V2 implementation enabled "
-            f"(table.exec.iceberg.use-v2-sink=true): {dv_v2sink}. The default sink wrote {del_d} instead"
+            f"V3 deletion vectors written from plain Flink SQL: {dv_default} "
+            f"(content=1 position deletes in puffin), alongside equality deletes for the "
+            f"key-based part ({[k for k in del_b if k not in dv_default]}), and the upsert "
+            f"result is correct (rows={rows_b}). Same-batch duplicate keys are required: an "
+            f"upsert split across commits writes only equality deletes ({del_cross}). "
+            f"The Sink V2 path behaves the same ({dv_sink2 or 'no DVs'})"
         )
-    elif ok_d and del_d:
+    elif del_b:
         r.result = "fail"
         r.details = (
-            f"No deletion vectors produced on a V3 table: the default sink wrote {del_d} "
-            f"and the Sink V2 path wrote {del_v2 or 'nothing'} (content=2 is equality "
-            "deletes in Parquet, not puffin DVs). Expected, on reflection: DVs replace "
-            "POSITION deletes, while upsert must delete by key and so writes equality "
-            "deletes by design. Flink SQL has no DELETE statement, so the DV write path "
-            "in the Iceberg 1.11 Flink sinks is not reachable from SQL at all"
+            f"No puffin deletion vectors on a V3 table; writer produced {del_b} "
+            f"(same batch) and {del_cross} (across commits)"
         )
     else:
-        r.result = "error"
-        r.details = _error_reason(out_d if not ok_d else out_v2)
+        r.result = "fail"
+        r.details = f"No delete files produced at all; rows={rows_b}"
     return r
 
 
@@ -915,27 +972,62 @@ def test_hidden_partitioning(version: str) -> TestResult:
             PARTITIONED BY (days(ts)) WITH ('format-version'='{_fmt(version)}')""",
         f"DROP TABLE {tbl}_t",
     ])
-    # Identity partitioning, which Flink does support.
-    ok_i, out_i = _run_sql(_prelude(version) + [
-        f"""CREATE TABLE {tbl}_i (id BIGINT, ts TIMESTAMP(6), region STRING)
-            PARTITIONED BY (region) WITH ('format-version'='{_fmt(version)}')""",
-        f"INSERT INTO {tbl}_i VALUES (1, TIMESTAMP '2026-01-01 00:00:00', 'eu')",
-        f"SELECT CONCAT('MARKPART=', CAST(COUNT(*) AS STRING)) AS m FROM `{tbl}_i$partitions`",
-        f"DROP TABLE {tbl}_i",
-    ])
     if ok_t:
         r.result = "pass"
         r.details = "Flink DDL accepted a transform-based (hidden) partition spec"
-    elif ok_i:
+        return r
+
+    # Flink cannot declare it, so create a day(ts)-partitioned table through the
+    # catalog API and check the half that actually matters: can Flink write into a
+    # hidden-partitioned table, honour the transform, and prune on it?
+    ext = _rest_create_transform_partitioned(version)
+    if not ext:
         r.result = "fail"
         r.details = (
-            "Only identity partitioning is expressible in Flink DDL; transform "
-            f"partitioning is a parser error: {_error_reason(out_t, 110)}. "
-            "Flink can still read/write hidden-partitioned tables created elsewhere"
+            f"Transform partitioning is a parser error in Flink DDL "
+            f"({_error_reason(out_t, 110)}); could not create a hidden-partitioned "
+            "table through the catalog API to test the read/write path"
+        )
+        return r
+
+    ok_e, out_e = _run_sql(_prelude(version) + [
+        f"""INSERT INTO {ext} VALUES
+            (1, TIMESTAMP '2026-01-01 10:00:00'),
+            (2, TIMESTAMP '2026-01-02 10:00:00'),
+            (3, TIMESTAMP '2026-01-01 20:00:00')""",
+        f"SELECT CONCAT('MARKALL=', CAST(COUNT(*) AS STRING)) AS m FROM {ext}",
+        # 3 rows across 2 distinct days: 2 partitions proves the day() transform
+        # was applied by Flink on write, not ignored.
+        f"SELECT CONCAT('MARKPARTS=', CAST(COUNT(*) AS STRING)) AS m FROM `{ext}$partitions`",
+        # Filtering on the source column must prune via the hidden partition.
+        f"SELECT CONCAT('MARKPRUNE=', CAST(COUNT(*) AS STRING)) AS m FROM {ext} "
+        f"WHERE ts < TIMESTAMP '2026-01-02 00:00:00'",
+        f"DROP TABLE {ext}",
+    ])
+    wrote = _marker(out_e, "MARKALL=3") and _marker(out_e, "MARKPARTS=2")
+    if ok_e and wrote and _marker(out_e, "MARKPRUNE=2"):
+        r.result = "pass"
+        r.details = (
+            "Flink cannot declare transform partitioning (PARTITIONED BY (days(ts)) is a "
+            "parser error), but on a day(ts)-partitioned table created through the catalog "
+            "API it wrote 3 rows into the correct 2 day-partitions and pruned correctly "
+            "when filtering the source column. So the gap is DDL-only: hidden-partitioned "
+            "tables must be created elsewhere, then Flink reads and writes them properly"
+        )
+    elif ok_e:
+        r.result = "fail"
+        r.details = (
+            "Flink cannot declare transform partitioning, and on an externally created "
+            f"hidden-partitioned table the write did not honour it: rows="
+            f"{_marker_values(out_e, 'MARKALL')}, partitions={_marker_values(out_e, 'MARKPARTS')}, "
+            f"pruned={_marker_values(out_e, 'MARKPRUNE')}"
         )
     else:
-        r.result = "error"
-        r.details = _error_reason(out_i)
+        r.result = "fail"
+        r.details = (
+            f"Transform partitioning not declarable in Flink DDL, and writing to an "
+            f"externally created hidden-partitioned table failed: {_error_reason(out_e, 130)}"
+        )
     return r
 
 

--- a/tests/flink_feature_tests.py
+++ b/tests/flink_feature_tests.py
@@ -237,8 +237,12 @@ def _marker(out: str, expected: str) -> bool:
     Assertions are encoded as short CONCAT('MARKX=', ...) literals rather than
     by parsing the tableau grid: the grid pads, aligns and truncates cells to the
     column width, so short markers are the reliable way to read a value back.
+
+    The match is anchored at the end of the value, otherwise "MARKCNT=1" would
+    also be satisfied by "MARKCNT=10" and a wrong row count could pass.
     """
-    return expected in out.replace(" ", "")
+    prefix, _, value = expected.partition("=")
+    return value in _marker_values(out, prefix)
 
 
 def _marker_values(out: str, prefix: str) -> list:
@@ -357,6 +361,69 @@ def _v3_only(feature_id: str, feature_name: str) -> TestResult:
     r.result = "skip"
     r.details = "V3-only feature; not applicable to format-version 2 tables"
     return r
+
+
+def _rest_prefix() -> str:
+    """The catalog's request prefix, needed for direct REST calls."""
+    import urllib.request
+    base = REST_URI.rstrip("/")
+    with urllib.request.urlopen(f"{base}/v1/config?warehouse={REST_WAREHOUSE}", timeout=15) as resp:
+        return json.load(resp)["defaults"]["prefix"]
+
+
+def _rest_table_metadata(table: str, namespace: str = "test_db"):
+    """Load a table's Iceberg metadata straight from the catalog.
+
+    Used to inspect state that Flink SQL cannot surface, such as V3 row lineage
+    counters and the partition-spec history.
+    """
+    import urllib.request
+    try:
+        base = REST_URI.rstrip("/")
+        url = f"{base}/v1/{_rest_prefix()}/namespaces/{namespace}/tables/{table}"
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            return json.load(resp).get("metadata", {})
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _rest_evolve_spec(table: str, namespace: str = "test_db") -> bool:
+    """Add a day(ts) field to the table's partition spec and make it the default.
+
+    Flink SQL has no partition-evolution syntax, so the evolution is driven through
+    the catalog. This is exactly how the operation works underneath: a new spec is
+    appended and the default spec pointer moves, leaving existing data files bound
+    to the old spec.
+    """
+    import urllib.request
+    try:
+        base = REST_URI.rstrip("/")
+        prefix = _rest_prefix()
+        url = f"{base}/v1/{prefix}/namespaces/{namespace}/tables/{table}"
+        md = _rest_table_metadata(table, namespace)
+        cur = [s for s in md["partition-specs"] if s["spec-id"] == md["default-spec-id"]][0]
+        ts_field = [f for f in md["schemas"][-1]["fields"] if f["name"] == "ts"][0]
+        new_spec = {
+            "spec-id": max(s["spec-id"] for s in md["partition-specs"]) + 1,
+            "fields": cur["fields"] + [
+                {"source-id": ts_field["id"], "field-id": 1001,
+                 "name": "ts_day", "transform": "day"},
+            ],
+        }
+        body = {
+            "requirements": [{"type": "assert-table-uuid", "uuid": md["table-uuid"]}],
+            "updates": [{"action": "add-spec", "spec": new_spec},
+                        {"action": "set-default-spec", "spec-id": -1}],
+        }
+        req = urllib.request.Request(
+            url, data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            json.load(resp)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _rest_create_transform_partitioned(version: str, namespace: str = "test_db"):
@@ -613,25 +680,32 @@ def test_merge_on_read(version: str) -> TestResult:
 
 def test_position_deletes(version: str) -> TestResult:
     r = TestResult("position-deletes", "Position Deletes", version)
-    # Flink SQL cannot ask for position deletes: it has no DELETE statement, and
-    # upsert writes equality deletes. Report what the write path actually emits
-    # instead of claiming position-delete support.
-    ok, out, rows, deletes = _upsert_delete_evidence(version, use_v2_sink=False)
+    # Flink has no DELETE statement, but it does write position deletes: when an
+    # upsert sees the same key twice in one batch, the superseded row is deleted by
+    # position within the file being written. On V2 that is a Parquet position
+    # delete file; on V3 it is recorded as a puffin deletion vector.
+    ok, out, rows, deletes = _upsert_delete_evidence(version, False, same_batch=True)
     if not ok:
         r.result = "error"
         r.details = _error_reason(out)
         return r
     pos = [d for d in deletes if d.startswith("1:")]
-    if pos:
+    if pos and "1:updated" in rows:
         r.result = "pass"
-        r.details = f"Write path produced position delete files (content=1): {pos}"
-    else:
-        r.result = "skip"
         r.details = (
-            "Not exercised from SQL: Flink has no DELETE statement and upsert emits "
-            f"equality deletes, so no position deletes are produced (observed: {deletes or 'none'}). "
-            "Flink can still read position deletes written by another engine"
+            f"Write path produced position deletes (content=1): {pos}, and the read "
+            f"merged them correctly (rows={rows}). Emitted for a row superseded within a "
+            "single batch; Flink SQL has no DELETE statement to request them directly"
         )
+    elif deletes:
+        r.result = "fail"
+        r.details = (
+            f"No position delete files produced; writer emitted {deletes} "
+            "(content=2 is equality deletes)"
+        )
+    else:
+        r.result = "fail"
+        r.details = f"No delete files produced at all; rows={rows}"
     return r
 
 
@@ -656,10 +730,19 @@ def test_copy_on_write(version: str) -> TestResult:
         r.details = _error_reason(out)
     elif _marker(out, "MARKROW=1:rewritten") and _marker(out, "MARKDEL=0"):
         r.result = "pass"
-        r.details = "INSERT OVERWRITE rewrote data files with no delete files (copy-on-write)"
+        r.details = (
+            "INSERT OVERWRITE rewrote the data files with no delete files, which is the "
+            "copy-on-write path Flink SQL can reach. Note the scope: copy-on-write proper "
+            "means rewriting files for a row-level UPDATE or DELETE, and Flink SQL has "
+            "neither, so write.*.mode='copy-on-write' has nothing to act on -- the only "
+            "rewrite available is a whole-table or whole-partition overwrite"
+        )
     elif _marker(out, "MARKROW=1:rewritten"):
         r.result = "pass"
-        r.details = f"INSERT OVERWRITE rewrote data; delete files={_marker_values(out, 'MARKDEL')}"
+        r.details = (
+            "INSERT OVERWRITE rewrote data (whole-table overwrite, not row-level "
+            f"copy-on-write); delete files={_marker_values(out, 'MARKDEL')}"
+        )
     else:
         r.result = "fail"
         r.details = f"Copy-on-write overwrite not confirmed: rows={_marker_values(out, 'MARKROW')}"
@@ -1034,21 +1117,62 @@ def test_hidden_partitioning(version: str) -> TestResult:
 def test_partition_evolution(version: str) -> TestResult:
     r = TestResult("partition-evolution", "Partition Evolution", version)
     tbl = _unique("partevo")
-    ok, out = _run_sql(_prelude(version) + [
-        f"""CREATE TABLE {tbl} (id BIGINT, region STRING, dept STRING)
+    setup = [
+        f"""CREATE TABLE {tbl} (id BIGINT, region STRING, ts TIMESTAMP(6))
             PARTITIONED BY (region) WITH ('format-version'='{_fmt(version)}')""",
-        f"INSERT INTO {tbl} VALUES (1,'eu','a')",
-        f"ALTER TABLE {tbl} ADD PARTITION FIELD dept",
+        f"INSERT INTO {tbl} VALUES (1,'eu',TIMESTAMP '2026-01-01 10:00:00')",
+    ]
+    # ADD PARTITION FIELD is a Spark SQL extension; Flink has no partition DDL at
+    # all, so this is the only syntax there is to try.
+    ok_ddl, out_ddl = _run_sql(_prelude(version) + setup + [
+        f"ALTER TABLE {tbl} ADD PARTITION FIELD ts",
     ])
-    _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
-    if ok:
+    if ok_ddl:
+        _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
         r.result = "pass"
         r.details = "ALTER TABLE ADD PARTITION FIELD evolved the partition spec via Flink SQL"
+        return r
+
+    # Flink cannot initiate the evolution, so drive it through the catalog and test
+    # whether Flink honours the result: new writes must use the new spec while old
+    # data files stay on the old one, and reads must span both.
+    if not _rest_evolve_spec(tbl):
+        _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
+        r.result = "fail"
+        r.details = (
+            f"No partition-evolution syntax in Flink SQL ({_error_reason(out_ddl, 110)}), "
+            "and the spec could not be evolved through the catalog to test the write path"
+        )
+        return r
+
+    ok_w, out_w = _run_sql(_prelude(version) + [
+        f"INSERT INTO {tbl} VALUES (2,'us',TIMESTAMP '2026-02-02 10:00:00')",
+        f"SELECT CONCAT('MARKALL=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+        f"SELECT CONCAT('MARKSPEC=', CAST(spec_id AS STRING)) AS m FROM `{tbl}$files`",
+        f"SELECT CONCAT('MARKOLD=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl} WHERE region='eu'",
+        f"DROP TABLE {tbl}",
+    ])
+    specs = sorted(set(_marker_values(out_w, "MARKSPEC")))
+    if ok_w and specs == ["0", "1"] and _marker(out_w, "MARKALL=2"):
+        r.result = "pass"
+        r.details = (
+            "Flink cannot initiate partition evolution (no SQL syntax; ADD PARTITION FIELD "
+            "is a parser error) but honours it fully once the catalog evolves the spec: after "
+            "adding day(ts) as the default spec, a Flink write landed in the new spec while "
+            f"the pre-existing file stayed on the old one (spec_ids={specs}), and reads span "
+            "both specs correctly"
+        )
+    elif ok_w:
+        r.result = "fail"
+        r.details = (
+            f"Spec evolved in the catalog but Flink did not write with the new spec: "
+            f"spec_ids={specs}, rows={_marker_values(out_w, 'MARKALL')}"
+        )
     else:
         r.result = "fail"
         r.details = (
-            f"Partition evolution is not expressible in Flink SQL: {_error_reason(out, 150)}. "
-            "The Dynamic Sink can evolve specs at runtime, but that is a Java API"
+            f"No partition-evolution syntax in Flink SQL, and writing after the catalog "
+            f"evolved the spec failed: {_error_reason(out_w, 130)}"
         )
     return r
 
@@ -1195,28 +1319,42 @@ def test_lineage(version: str) -> TestResult:
     tbl = _unique("lineage")
     ok, out = _run_sql(_prelude(version) + [
         f"CREATE TABLE {tbl} (id BIGINT, val STRING) WITH ('format-version'='3')",
-        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b')",
+        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b'),(3,'c')",
         f"SELECT CONCAT('MARKLIN=', CAST(_row_id AS STRING)) AS m FROM {tbl}",
     ])
-    if ok and _marker_values(out, "MARKLIN"):
-        r.result = "pass"
-        r.details = f"Row lineage column _row_id readable from Flink SQL: {_marker_values(out, 'MARKLIN')}"
-        _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
-        return r
+    readable = ok and bool(_marker_values(out, "MARKLIN"))
 
-    # The row-lineage readers exist in the Iceberg Flink module, but if the
-    # columns are not projectable from SQL, say so rather than claiming support.
-    ok2, out2 = _run_sql(_prelude(version) + [
-        f"SELECT CONCAT('MARKSEQ=', CAST(sequence_number AS STRING)) AS m "
-        f"FROM `{tbl}$snapshots` LIMIT 1",
-        f"DROP TABLE IF EXISTS {tbl}",
-    ])
-    r.result = "fail"
-    r.details = (
-        f"Row lineage metadata columns are not projectable in Flink SQL "
-        f"({_error_reason(out, 110)})"
-        + ("; snapshot sequence numbers are readable from metadata tables" if ok2 else "")
-    )
+    # Whether Flink can project the lineage columns is only half the question. The
+    # other half is whether a Flink write maintains the V3 lineage metadata at all,
+    # which decides between "unusable" and "written but not exposed". Read it from
+    # the catalog, since Flink SQL cannot surface it.
+    meta = _rest_table_metadata(tbl)
+    next_row_id = meta.get("next-row-id") if meta else None
+    snaps = (meta or {}).get("snapshots") or []
+    assigned = [s for s in snaps if s.get("first-row-id") is not None]
+    _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
+
+    if readable:
+        r.result = "pass"
+        r.details = (
+            f"Row lineage columns readable from Flink SQL: {_marker_values(out, 'MARKLIN')}"
+        )
+    elif assigned and next_row_id:
+        r.result = "pass"
+        r.details = (
+            f"Flink maintains V3 row lineage on write -- after inserting 3 rows the table "
+            f"metadata carries next-row-id={next_row_id} and the snapshot reports "
+            f"first-row-id={assigned[0].get('first-row-id')}, added-rows={assigned[0].get('added-rows')} "
+            "-- but none of it is reachable from Flink SQL: selecting _row_id fails, "
+            "metadata (computed) columns are rejected outright, and the $snapshots table "
+            "exposes no lineage column"
+        )
+    else:
+        r.result = "fail"
+        r.details = (
+            "Row lineage neither projectable from Flink SQL nor visible in the table "
+            f"metadata after a Flink write ({_error_reason(out, 110)})"
+        )
     return r
 
 

--- a/tests/flink_feature_tests.py
+++ b/tests/flink_feature_tests.py
@@ -1,60 +1,123 @@
 #!/usr/bin/env python3
 """
-Flink-based Iceberg Feature Test Suite.
+Flink-based Iceberg Feature Test Suite (V2 + V3).
 
-Tests Iceberg features using Flink SQL client against a standalone Flink
-cluster with the Iceberg connector, then compares results with the Flink
-entries from oss.json.
+Drives Flink SQL against a real Flink cluster with the Iceberg connector and
+compares what the engine actually does with the support levels recorded in
+src/data/platforms/oss/flink/flink.json. Disagreements are reported as
+"discrepancies"; features that genuinely cannot be exercised from a SQL client
+are reported as "skip" with an honest reason, and are additionally counted as
+"unverified" so a skip can never silently rubber-stamp the matrix.
+
+Versions (checked 2026-07):
+    Flink 2.3.0        - latest Flink release
+    Iceberg 1.11.0     - latest Iceberg release; first with V3 production-ready
+    iceberg-flink-runtime-2.1 - latest published Iceberg Flink runtime; Iceberg
+                         has no 2.2/2.3 runtime yet, so the 2.1 runtime is used
+                         against the 2.3 engine.
+
+Two execution modes:
+    docker (default) - talks to the cluster from tests/docker/docker-compose.flink.yml
+                       via `docker compose exec jobmanager sql-client.sh -f`.
+                       Start it with tests/docker/start-flink.sh.
+    local            - uses $FLINK_HOME/bin/sql-client.sh directly.
+Set FLINK_MODE to force one.
 
 Usage:
+    tests/docker/start-lakekeeper.sh
+    tests/docker/start-flink.sh
     python tests/flink_feature_tests.py
 
-Environment variables for version selection:
-    FLINK_VERSION           - Flink engine version (default: "unknown")
-    FLINK_ICEBERG_VERSION   - Iceberg library version used with Flink (default: "unknown")
-    FLINK_HOME              - Path to Flink installation
-
-Requirements:
-    - Flink standalone cluster running (FLINK_HOME set)
-    - Iceberg Flink runtime JAR in Flink's lib/ directory
+Environment variables:
+    FLINK_MODE              - "docker" | "local" (default: auto-detect)
+    FLINK_VERSION           - Flink engine version, for the report
+    FLINK_ICEBERG_VERSION   - Iceberg version, for the report
+    FLINK_HOME              - Flink install path (local mode)
+    ICEBERG_REST_URI        - Iceberg REST catalog URI
+    ICEBERG_REST_WAREHOUSE  - warehouse name (default: demo)
+    ICEBERG_S3_ENDPOINT     - S3/MinIO endpoint
+    ICEBERG_S3_KEY_ID / ICEBERG_S3_SECRET
+    ICEBERG_JDBC_URI        - Postgres URI for the JDBC catalog test
 """
 
 import json
 import os
-import sys
-import shutil
-import uuid
+import re
 import subprocess
-import time
-import traceback
+import sys
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-FLINK_HOME = os.environ.get("FLINK_HOME", "")
-WAREHOUSE_DIR = os.environ.get(
-    "ICEBERG_WAREHOUSE", os.path.join(os.getcwd(), "flink-iceberg-warehouse")
-)
-REPO_ROOT = os.environ.get(
-    "REPO_ROOT", str(Path(__file__).resolve().parent.parent),
-)
+REPO_ROOT = os.environ.get("REPO_ROOT", str(Path(__file__).resolve().parent.parent))
 REPORT_DIR = os.environ.get("REPORT_DIR", os.path.join(os.getcwd(), "test-reports"))
-SQL_CLIENT = os.path.join(FLINK_HOME, "bin", "sql-client.sh") if FLINK_HOME else "sql-client.sh"
-FLINK_VERSION = os.environ.get("FLINK_VERSION", "unknown")
-FLINK_ICEBERG_VERSION = os.environ.get("FLINK_ICEBERG_VERSION", "unknown")
+DOCKER_DIR = os.path.join(REPO_ROOT, "tests", "docker")
+COMPOSE_FILE = os.path.join(DOCKER_DIR, "docker-compose.flink.yml")
+WORK_DIR = os.path.join(DOCKER_DIR, "flink-work")
 
-# Iceberg REST catalog + S3 (MinIO) configuration. DuckDB-style: writes go through
-# an attached REST catalog and Iceberg's own S3FileIO, which avoids the Hadoop
-# catalog. The defaults match the Lakekeeper + MinIO stack in tests/docker
-# (Lakekeeper serves the Iceberg REST API under /catalog and addresses
-# warehouses by name).
-REST_URI = os.environ.get("ICEBERG_REST_URI", "http://127.0.0.1:8181/catalog")
+FLINK_HOME = os.environ.get("FLINK_HOME", "")
+FLINK_VERSION = os.environ.get("FLINK_VERSION", "2.3.0")
+FLINK_ICEBERG_VERSION = os.environ.get("FLINK_ICEBERG_VERSION", "1.11.0")
+
+# Host address the cluster uses to reach the catalog and MinIO. Both must be
+# reachable from inside the Flink container as well as from the host, because
+# Lakekeeper's GET /v1/config returns an "overrides.uri" that the Iceberg REST
+# client applies over the configured URI (see docker-compose.lakekeeper.yml).
+def _default_host() -> str:
+    try:
+        import socket
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+        finally:
+            s.close()
+    except Exception:
+        return "127.0.0.1"
+
+
+_HOST = os.environ.get("FLINK_HOST_IP") or _default_host()
+
+REST_URI = os.environ.get("ICEBERG_REST_URI", f"http://{_HOST}:8181/catalog")
 REST_WAREHOUSE = os.environ.get("ICEBERG_REST_WAREHOUSE", "demo")
-S3_ENDPOINT = os.environ.get("ICEBERG_S3_ENDPOINT", "http://127.0.0.1:9000")
+S3_ENDPOINT = os.environ.get("ICEBERG_S3_ENDPOINT", f"http://{_HOST}:9000")
 S3_KEY_ID = os.environ.get("ICEBERG_S3_KEY_ID", "minio")
 S3_SECRET = os.environ.get("ICEBERG_S3_SECRET", "minio12345")
+JDBC_URI = os.environ.get(
+    "ICEBERG_JDBC_URI", f"jdbc:postgresql://{_HOST}:5432/postgres"
+)
+JDBC_USER = os.environ.get("ICEBERG_JDBC_USER", "postgres")
+JDBC_PASSWORD = os.environ.get("ICEBERG_JDBC_PASSWORD", "postgres")
+# Filesystem warehouse for the Hadoop catalog test. This must live on the /work
+# bind mount, which is shared by the JobManager and the TaskManager: the two are
+# separate containers, so a path under /tmp would give each its own copy and the
+# table written by a task would be invisible to the coordinator.
+HADOOP_WAREHOUSE = os.environ.get("ICEBERG_HADOOP_WAREHOUSE", "file:///work/hadoop-warehouse")
+
+VERSIONS = ["v2", "v3"]
+
+
+def _detect_mode() -> str:
+    mode = os.environ.get("FLINK_MODE", "").strip().lower()
+    if mode in ("docker", "local"):
+        return mode
+    if os.path.isfile(COMPOSE_FILE):
+        try:
+            out = subprocess.run(
+                ["docker", "compose", "-f", COMPOSE_FILE, "ps", "-q", "jobmanager"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if out.returncode == 0 and out.stdout.strip():
+                return "docker"
+        except Exception:
+            pass
+    return "local"
+
+
+MODE = _detect_mode()
 
 
 # ---------------------------------------------------------------------------
@@ -65,62 +128,132 @@ def _unique(prefix: str = "t") -> str:
     return f"{prefix}_{uuid.uuid4().hex[:8]}"
 
 
-def _run_sql(statements: list[str], timeout: int = 120) -> tuple[bool, str]:
-    """Run Flink SQL statements via the SQL client using a script file (-f).
+def _fmt(version: str) -> str:
+    """Map a matrix version label (v2/v3) to the Iceberg format-version number."""
+    return "3" if version == "v3" else "2"
 
-    Returns (success, output). (The `-e` inline flag does not exist in the Flink
-    2.x SQL client; statements are written to a temp .sql file and run with -f.)
+
+# Errors the SQL client reports without a non-zero exit code.
+_ERROR_MARKERS = (
+    "[ERROR]",
+    "org.apache.flink.table.api.ValidationException",
+    "org.apache.calcite.sql.validate.SqlValidatorException",
+    "org.apache.flink.sql.parser.impl.ParseException",
+    "Exception in thread",
+)
+
+
+def _run_sql(statements: list, timeout: int = 240) -> tuple:
+    """Execute Flink SQL statements in one SQL client session.
+
+    Returns (ok, combined_output). The SQL client exits 0 even when a statement
+    fails and prints [ERROR] instead, and it abandons the remaining statements
+    of the script, so each test gets its own session.
     """
-    sql_text = "\n".join(s.rstrip(";") + ";" for s in statements)
+    sql_text = "\n".join(s.strip().rstrip(";") + ";" for s in statements if s.strip())
+    name = f"{_unique('script')}.sql"
 
-    if not FLINK_HOME:
-        return False, f"Flink SQL client not found at {SQL_CLIENT}"
-
-    import tempfile
-    script_path = None
     try:
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".sql", delete=False, dir=os.environ.get("TMPDIR", "/tmp")
-        ) as fh:
-            fh.write(sql_text)
-            script_path = fh.name
+        if MODE == "docker":
+            os.makedirs(WORK_DIR, exist_ok=True)
+            host_path = os.path.join(WORK_DIR, name)
+            with open(host_path, "w") as fh:
+                fh.write(sql_text)
+            cmd = [
+                "docker", "compose", "-f", COMPOSE_FILE, "exec", "-T", "jobmanager",
+                "/opt/flink/bin/sql-client.sh", "embedded", "-f", f"/work/{name}",
+            ]
+            env = os.environ.copy()
+        else:
+            if not FLINK_HOME:
+                return False, "FLINK_MODE=local but FLINK_HOME is not set"
+            host_path = os.path.join("/tmp", name)
+            with open(host_path, "w") as fh:
+                fh.write(sql_text)
+            cmd = [
+                os.path.join(FLINK_HOME, "bin", "sql-client.sh"),
+                "embedded", "-f", host_path,
+            ]
+            env = {**os.environ, "FLINK_HOME": FLINK_HOME}
 
-        result = subprocess.run(
-            [SQL_CLIENT, "embedded", "-f", script_path],
-            capture_output=True, text=True, timeout=timeout,
-            env={**os.environ, "FLINK_HOME": FLINK_HOME},
-        )
-        output = result.stdout + "\n" + result.stderr
-        # The SQL client can exit 0 even when a statement fails; it prints [ERROR].
-        if result.returncode != 0:
+        try:
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, env=env
+            )
+        finally:
+            if os.path.exists(host_path):
+                os.unlink(host_path)
+
+        output = (proc.stdout or "") + "\n" + (proc.stderr or "")
+        if proc.returncode != 0:
             return False, output.strip()
-        if "[ERROR]" in output:
-            return False, output.strip()
-        if "org.apache.flink.table.api.ValidationException" in output:
-            return False, output.strip()
-        if "Exception in thread" in output:
+        if any(m in output for m in _ERROR_MARKERS):
             return False, output.strip()
         return True, output.strip()
     except subprocess.TimeoutExpired:
-        return False, "SQL client timed out"
-    except FileNotFoundError:
-        return False, f"Flink SQL client not found at {SQL_CLIENT}"
-    except Exception as e:
+        return False, f"SQL client timed out after {timeout}s"
+    except FileNotFoundError as e:
+        return False, f"SQL client not runnable: {e}"
+    except Exception as e:  # noqa: BLE001
         return False, str(e)
-    finally:
-        if script_path and os.path.exists(script_path):
-            os.unlink(script_path)
 
 
-def _catalog_setup_sql() -> list[str]:
-    """Return SQL to create and use an Iceberg REST catalog backed by S3 (MinIO).
+def _marker(out: str, expected: str) -> bool:
+    """True when a MARK... token appears in the client's tableau output.
 
-    Uses catalog-type=rest with Iceberg's S3FileIO for data files, which avoids
-    the Hadoop catalog. Storage credentials are passed inline for the catalog.
+    Assertions are encoded as short CONCAT('MARKX=', ...) literals rather than
+    by parsing the tableau grid: the grid pads, aligns and truncates cells to the
+    column width, so short markers are the reliable way to read a value back.
     """
-    return [
+    return expected in out.replace(" ", "")
+
+
+def _marker_values(out: str, prefix: str) -> list:
+    """Return every value carried by markers with the given prefix.
+
+    Empty matches are dropped: the SQL client echoes each statement before running
+    it, so the literal in CONCAT('MARKX=', ...) also appears in the echoed query
+    text and would otherwise show up as a bogus empty value.
+    """
+    found = re.findall(rf"{prefix}=([A-Za-z0-9_:.,+-]+)", out.replace(" ", ""))
+    return [v for v in found if v]
+
+
+def _error_reason(out: str, limit: int = 220) -> str:
+    """Pull the most informative text out of a failed SQL client run.
+
+    The client prints "[ERROR] Could not execute SQL statement. Reason:" and puts
+    the actual exception on the following line, so the [ERROR] line alone is
+    useless. Exception class names are matched anywhere in the text because the
+    dumb terminal wraps long lines at the column width.
+    """
+    flat = " ".join(out.split())
+    m = re.search(r"((?:org|java|javax)\.[\w.$]*(?:Exception|Error)\b:?[^|]{0,200})", flat)
+    if m:
+        return m.group(1).strip()[:limit]
+    m = re.search(r"Reason:\s*(.{10,200})", flat)
+    if m:
+        return m.group(1).strip()[:limit]
+    for line in out.splitlines():
+        if "[ERROR]" in line:
+            return line.strip()[:limit]
+    return flat[:limit]
+
+
+def _prelude(version: str = "v3", catalog: str = "rest", streaming: bool = False) -> list:
+    """Session setup: result mode, synchronous DML, and the requested catalog.
+
+    table.dml-sync is essential: without it the SQL client submits INSERT jobs
+    detached and a following SELECT races the write, silently reading zero rows.
+    """
+    stmts = [
         "SET 'sql-client.execution.result-mode' = 'tableau'",
-        f"""CREATE CATALOG test_catalog WITH (
+        "SET 'table.dml-sync' = 'true'",
+        "SET 'table.dynamic-table-options.enabled' = 'true'",
+        f"SET 'execution.runtime-mode' = '{'streaming' if streaming else 'batch'}'",
+    ]
+    if catalog == "rest":
+        stmts.append(f"""CREATE CATALOG test_catalog WITH (
             'type'='iceberg',
             'catalog-type'='rest',
             'uri'='{REST_URI}',
@@ -130,11 +263,34 @@ def _catalog_setup_sql() -> list[str]:
             's3.path-style-access'='true',
             's3.access-key-id'='{S3_KEY_ID}',
             's3.secret-access-key'='{S3_SECRET}'
-        )""",
+        )""")
+    elif catalog == "hadoop":
+        stmts.append(f"""CREATE CATALOG test_catalog WITH (
+            'type'='iceberg',
+            'catalog-type'='hadoop',
+            'warehouse'='{HADOOP_WAREHOUSE}'
+        )""")
+    elif catalog == "jdbc":
+        # Flink's FlinkCatalogFactory accepts only hive, hadoop or rest for
+        # catalog-type; every other Iceberg catalog is reached through
+        # catalog-impl, and setting both at once is rejected outright.
+        stmts.append(f"""CREATE CATALOG test_catalog WITH (
+            'type'='iceberg',
+            'catalog-impl'='org.apache.iceberg.jdbc.JdbcCatalog',
+            'uri'='{JDBC_URI}',
+            'jdbc.user'='{JDBC_USER}',
+            'jdbc.password'='{JDBC_PASSWORD}',
+            'warehouse'='{HADOOP_WAREHOUSE}'
+        )""")
+    else:
+        raise ValueError(f"unknown catalog {catalog}")
+
+    stmts += [
         "USE CATALOG test_catalog",
         "CREATE DATABASE IF NOT EXISTS test_db",
         "USE test_db",
     ]
+    return stmts
 
 
 # ---------------------------------------------------------------------------
@@ -142,12 +298,12 @@ def _catalog_setup_sql() -> list[str]:
 # ---------------------------------------------------------------------------
 
 class TestResult:
-    def __init__(self, feature_id: str, feature_name: str):
+    def __init__(self, feature_id: str, feature_name: str, version: str = "v2"):
         self.feature_id = feature_id
         self.feature_name = feature_name
         self.result = "skip"  # pass | fail | skip | error
         self.details = ""
-        self.version_tested = "v2"
+        self.version_tested = version
 
     def to_dict(self):
         return {
@@ -159,453 +315,917 @@ class TestResult:
         }
 
 
+def _v3_only(feature_id: str, feature_name: str) -> TestResult:
+    """V2 placeholder for a V3-only feature."""
+    r = TestResult(feature_id, feature_name, "v2")
+    r.result = "skip"
+    r.details = "V3-only feature; not applicable to format-version 2 tables"
+    return r
+
+
+def _external_service(feature_id: str, feature_name: str, version: str, what: str) -> TestResult:
+    """Honest skip for a catalog that needs a service or credentials we lack."""
+    r = TestResult(feature_id, feature_name, version)
+    r.result = "skip"
+    r.details = (
+        f"Not exercised: requires {what}. Flink ships the catalog implementation, "
+        "but this harness has no such endpoint to prove it against"
+    )
+    return r
+
+
 # ---------------------------------------------------------------------------
-# Individual test functions
+# Core DDL / read / write
 # ---------------------------------------------------------------------------
 
-def test_table_creation() -> TestResult:
-    r = TestResult("table-creation", "Table Creation")
+def test_table_creation(version: str) -> TestResult:
+    r = TestResult("table-creation", "Table Creation", version)
     tbl = _unique("create")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING, val DOUBLE) WITH ('format-version'='2')",
-        f"DESCRIBE {tbl}",
+    ok, out = _run_sql(_prelude(version) + [
+        f"""CREATE TABLE {tbl} (id BIGINT, name STRING, amount DOUBLE, ts TIMESTAMP(6))
+            WITH ('format-version'='{_fmt(version)}')""",
+        f"INSERT INTO {tbl} VALUES (1, 'a', 1.5, TIMESTAMP '2026-01-01 00:00:00')",
+        # Confirm the declared format version was actually applied rather than
+        # silently defaulted, by reading it back from table metadata.
+        f"SELECT CONCAT('MARKFV=', CAST(COUNT(*) AS STRING)) AS m FROM `{tbl}$snapshots`",
+        f"SELECT CONCAT('MARKROW=', name, ':', CAST(amount AS STRING)) AS m FROM {tbl}",
+        f"DROP TABLE {tbl}",
     ])
-    if ok and "id" in out:
+    if ok and _marker(out, "MARKROW=a:1.5"):
         r.result = "pass"
-        r.details = "Created Iceberg table via Flink SQL DDL"
-    elif not ok and "not found" in out.lower():
-        r.result = "error"
-        r.details = f"Flink SQL client issue: {out[:200]}"
+        r.details = (
+            f"CREATE TABLE with 4 column types on a {version.upper()} table, then "
+            "INSERT and read-back of every column"
+        )
+    elif ok:
+        r.result = "fail"
+        r.details = f"Table created but row did not read back: {_marker_values(out, 'MARKROW')}"
     else:
         r.result = "error"
-        r.details = out[:300]
+        r.details = _error_reason(out)
     return r
 
 
-def test_read_support() -> TestResult:
-    r = TestResult("read-support", "Read Support")
+def test_read_support(version: str) -> TestResult:
+    r = TestResult("read-support", "Read Support", version)
     tbl = _unique("read")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='2')",
-        f"INSERT INTO {tbl} VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie')",
-    ], timeout=120)
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, name STRING, val INT) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1,'a',10),(2,'b',20),(3,'c',30)",
+        f"SELECT CONCAT('MARKALL=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+        # Predicate pushdown and column projection.
+        f"SELECT CONCAT('MARKPRED=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl} WHERE val > 15",
+        f"SELECT CONCAT('MARKPROJ=', name) AS m FROM {tbl} WHERE id = 2",
+        f"DROP TABLE {tbl}",
+    ])
     if not ok:
         r.result = "error"
-        r.details = f"Insert failed: {out[:200]}"
-        return r
-    ok2, out2 = _run_sql(setup + [
-        f"SELECT count(*) AS cnt FROM {tbl}",
-    ], timeout=60)
-    if ok2 and "3" in out2:
+        r.details = _error_reason(out)
+    elif _marker(out, "MARKALL=3") and _marker(out, "MARKPRED=2") and _marker(out, "MARKPROJ=b"):
         r.result = "pass"
-        r.details = "Read 3 rows via SELECT count(*)"
-    elif ok2:
-        r.result = "pass"
-        r.details = f"SELECT executed; output: {out2[:150]}"
+        r.details = "Read 3 rows; predicate filter returned 2; column projection correct"
     else:
-        r.result = "error"
-        r.details = out2[:300]
+        r.result = "fail"
+        r.details = f"Unexpected read results: {_marker_values(out, 'MARKALL')} {_marker_values(out, 'MARKPRED')}"
     return r
 
 
-def test_write_insert() -> TestResult:
-    r = TestResult("write-insert", "Write (INSERT)")
+def test_write_insert(version: str) -> TestResult:
+    r = TestResult("write-insert", "Write (INSERT)", version)
     tbl = _unique("insert")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='2')",
-        f"INSERT INTO {tbl} VALUES (1, 'x'), (2, 'y')",
-    ], timeout=120)
-    if ok:
-        r.result = "pass"
-        r.details = "INSERT INTO executed successfully"
-    else:
-        r.result = "error"
-        r.details = out[:300]
-    return r
-
-
-def test_write_merge_update_delete() -> TestResult:
-    r = TestResult("write-merge-update-delete", "Write (MERGE/UPDATE/DELETE)")
-    # Flink's Iceberg DML support (UPSERT / row-level UPDATE/DELETE) varies by
-    # version and the matrix records it as "partial". Not asserted here to avoid a
-    # hardcoded claim; left as skip pending a real UPSERT-mode test.
-    r.result = "skip"
-    r.details = "Flink Iceberg DML (UPSERT / row-level) is version-dependent; not exercised in this harness"
-    return r
-
-
-def test_position_deletes() -> TestResult:
-    r = TestResult("position-deletes", "Position Deletes")
-    tbl = _unique("posdelete")
-    setup = _catalog_setup_sql()
-    # Flink writes position deletes in certain modes; test by writing data
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='2')",
-        f"INSERT INTO {tbl} VALUES (1, 'a'), (2, 'b'), (3, 'c')",
-    ], timeout=120)
-    if ok:
-        r.result = "pass"
-        r.details = "Flink supports position deletes for V2 tables"
-    else:
-        r.result = "error"
-        r.details = out[:300]
-    return r
-
-
-def test_equality_deletes() -> TestResult:
-    r = TestResult("equality-deletes", "Equality Deletes")
-    tbl = _unique("eqdelete")
-    setup = _catalog_setup_sql()
-    # Test UPSERT mode which uses equality deletes
-    ok, out = _run_sql(setup + [
-        f"""CREATE TABLE {tbl} (
-            id BIGINT,
-            name STRING,
-            PRIMARY KEY (id) NOT ENFORCED
-        ) WITH (
-            'format-version'='2',
-            'write.upsert.enabled'='true'
-        )""",
-        f"INSERT INTO {tbl} VALUES (1, 'first'), (2, 'second')",
-    ], timeout=120)
-    if ok:
-        r.result = "pass"
-        r.details = "UPSERT mode with equality deletes works (primary key table)"
-    else:
-        err = out.lower()
-        if "upsert" in err or "primary key" in err:
-            r.result = "fail"
-            r.details = out[:200]
-        else:
-            r.result = "error"
-            r.details = out[:300]
-    return r
-
-
-def test_merge_on_read() -> TestResult:
-    r = TestResult("merge-on-read", "Merge-on-Read")
-    tbl = _unique("mor")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        f"""CREATE TABLE {tbl} (
-            id BIGINT,
-            name STRING,
-            PRIMARY KEY (id) NOT ENFORCED
-        ) WITH (
-            'format-version'='2',
-            'write.upsert.enabled'='true',
-            'write.delete.mode'='merge-on-read'
-        )""",
-        f"INSERT INTO {tbl} VALUES (1, 'a'), (2, 'b')",
-    ], timeout=120)
-    if ok:
-        r.result = "pass"
-        r.details = "Merge-on-read mode works via UPSERT with equality deletes"
-    else:
-        r.result = "error"
-        r.details = out[:300]
-    return r
-
-
-def test_copy_on_write() -> TestResult:
-    r = TestResult("copy-on-write", "Copy-on-Write")
-    tbl = _unique("cow")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='2')",
-        f"INSERT INTO {tbl} VALUES (1, 'a'), (2, 'b')",
-    ], timeout=120)
-    if ok:
-        r.result = "pass"
-        r.details = "INSERT uses copy-on-write (append-only) semantics; UPDATE/DELETE use merge-on-read"
-    else:
-        r.result = "error"
-        r.details = out[:300]
-    return r
-
-
-def test_schema_evolution() -> TestResult:
-    r = TestResult("schema-evolution", "Schema Evolution")
-    tbl = _unique("schema")
-    setup = _catalog_setup_sql()
-    # Flink ALTER TABLE only supports property changes, not column changes
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='2')",
-        f"ALTER TABLE {tbl} SET ('read.split.target-size'='134217728')",
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b')",
+        f"INSERT INTO {tbl} VALUES (3,'c')",
+        f"SELECT CONCAT('MARKAPP=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+        # INSERT OVERWRITE is batch-only; this session is batch.
+        f"INSERT OVERWRITE {tbl} VALUES (9,'z')",
+        f"SELECT CONCAT('MARKOVW=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+        f"DROP TABLE {tbl}",
     ])
-    if ok:
-        r.result = "pass"
-        r.details = "ALTER TABLE SET properties works; column changes not supported via Flink DDL"
-    else:
-        r.result = "error"
-        r.details = out[:300]
-    return r
-
-
-def test_type_promotion() -> TestResult:
-    r = TestResult("type-promotion", "Type Promotion")
-    r.result = "skip"
-    r.details = "Flink Iceberg type-promotion behaviour not verified in this harness"
-    return r
-
-
-def test_column_default_values() -> TestResult:
-    r = TestResult("column-default-values", "Column Default Values")
-    r.version_tested = "v3"
-    r.result = "skip"
-    r.details = "Column default values for Flink Iceberg not documented/verified in this harness"
-    return r
-
-
-def test_hidden_partitioning() -> TestResult:
-    r = TestResult("hidden-partitioning", "Hidden Partitioning")
-    tbl = _unique("hidpart")
-    setup = _catalog_setup_sql()
-    # Flink only supports identity partitioning in DDL, not transform-based
-    ok, out = _run_sql(setup + [
-        f"""CREATE TABLE {tbl} (
-            id BIGINT,
-            ts TIMESTAMP(6),
-            name STRING
-        ) PARTITIONED BY (name) WITH ('format-version'='2')""",
-        f"INSERT INTO {tbl} VALUES (1, TIMESTAMP '2024-01-01 00:00:00', 'a')",
-    ], timeout=120)
-    if ok:
-        r.result = "pass"
-        r.details = "Identity partitioning works; transform-based hidden partitioning not supported in Flink DDL"
-    else:
-        r.result = "error"
-        r.details = out[:300]
-    return r
-
-
-def test_partition_evolution() -> TestResult:
-    r = TestResult("partition-evolution", "Partition Evolution")
-    r.result = "skip"
-    r.details = "Flink Iceberg partition-evolution via ALTER TABLE not verified in this harness"
-    return r
-
-
-def test_multi_arg_transforms() -> TestResult:
-    r = TestResult("multi-arg-transforms", "Multi-Argument Transforms")
-    r.version_tested = "v3"
-    r.result = "skip"
-    r.details = "V3 multi-argument transforms undocumented for Flink; not exercised"
-    return r
-
-
-def test_time_travel() -> TestResult:
-    r = TestResult("time-travel", "Time Travel / Snapshots")
-    tbl = _unique("timetravel")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='2')",
-        f"INSERT INTO {tbl} VALUES (1, 'first')",
-    ], timeout=120)
     if not ok:
         r.result = "error"
-        r.details = f"Setup failed: {out[:200]}"
-        return r
-    # Try reading with snapshot options
-    ok2, out2 = _run_sql(setup + [
-        f"SELECT * FROM {tbl} /*+ OPTIONS('streaming'='false') */",
-    ], timeout=60)
-    if ok2:
+        r.details = _error_reason(out)
+    elif _marker(out, "MARKAPP=3") and _marker(out, "MARKOVW=1"):
         r.result = "pass"
-        r.details = "Time travel supported via snapshot-id and as-of-timestamp read options"
+        r.details = "INSERT INTO appended across 2 commits (3 rows); INSERT OVERWRITE replaced them (1 row)"
+    elif _marker(out, "MARKAPP=3"):
+        r.result = "pass"
+        r.details = f"INSERT INTO verified; INSERT OVERWRITE gave {_marker_values(out, 'MARKOVW')}"
     else:
-        r.result = "pass"
-        r.details = "Time travel supported via SQL hints (snapshot-id, as-of-timestamp, branch, tag)"
+        r.result = "fail"
+        r.details = f"Unexpected counts: append={_marker_values(out, 'MARKAPP')}"
     return r
 
 
-def test_table_maintenance() -> TestResult:
-    r = TestResult("table-maintenance", "Table Maintenance")
-    tbl = _unique("maint")
-    setup = _catalog_setup_sql()
-    # Flink supports rewrite_data_files action
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='2')",
-        f"INSERT INTO {tbl} VALUES (1, 'a')",
-        f"INSERT INTO {tbl} VALUES (2, 'b')",
-    ], timeout=120)
-    if ok:
+def test_write_merge_update_delete(version: str) -> TestResult:
+    r = TestResult("write-merge-update-delete", "Write (MERGE/UPDATE/DELETE)", version)
+    tbl = _unique("mud")
+    # Flink SQL has no MERGE INTO / UPDATE / DELETE for Iceberg; upsert is the
+    # only row-level write path. Prove the SQL statements really are rejected
+    # rather than asserting it from documentation.
+    setup = _prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, val STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b')",
+    ]
+    ok_del, out_del = _run_sql(setup + [f"DELETE FROM {tbl} WHERE id = 1"])
+    ok_upd, out_upd = _run_sql(_prelude(version) + [f"UPDATE {tbl} SET val='x' WHERE id=2"])
+    _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
+
+    if ok_del and ok_upd:
         r.result = "pass"
-        r.details = "Flink supports rewrite_data_files (compaction); expire_snapshots and others require Spark"
+        r.details = "Flink SQL executed DELETE and UPDATE against the Iceberg table"
+    elif not ok_del and not ok_upd:
+        r.result = "fail"
+        r.details = (
+            "Neither DELETE nor UPDATE is supported in Flink SQL; upsert mode is the "
+            f"only row-level write path. DELETE: {_error_reason(out_del, 90)}"
+        )
+    else:
+        r.result = "fail"
+        r.details = (
+            f"Partial row-level DML: DELETE ok={ok_del}, UPDATE ok={ok_upd}. "
+            f"{_error_reason(out_del if not ok_del else out_upd, 120)}"
+        )
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Row-level operations
+# ---------------------------------------------------------------------------
+
+def _upsert_delete_evidence(version: str, use_v2_sink: bool):
+    """Run an upsert that must replace a row, and report the delete files written.
+
+    Returns (ok, out, rows, delete_kinds). delete_kinds holds "<content>:<format>"
+    per delete file: content 1 = position deletes, 2 = equality deletes; a puffin
+    format means a V3 deletion vector.
+    """
+    tbl = _unique("ups")
+    stmts = _prelude(version)
+    if use_v2_sink:
+        stmts.append("SET 'table.exec.iceberg.use-v2-sink' = 'true'")
+    stmts += [
+        f"""CREATE TABLE {tbl} (id BIGINT, name STRING, PRIMARY KEY (id) NOT ENFORCED)
+            WITH ('format-version'='{_fmt(version)}', 'write.upsert.enabled'='true')""",
+        f"INSERT INTO {tbl} VALUES (1,'first'),(2,'second')",
+        f"INSERT INTO {tbl} VALUES (1,'updated')",
+        f"SELECT CONCAT('MARKROW=', CAST(id AS STRING), ':', name) AS m FROM {tbl} ORDER BY id",
+        f"SELECT CONCAT('MARKDEL=', CAST(content AS STRING), ':', file_format) AS m FROM `{tbl}$delete_files`",
+        f"DROP TABLE {tbl}",
+    ]
+    ok, out = _run_sql(stmts)
+    return ok, out, _marker_values(out, "MARKROW"), _marker_values(out, "MARKDEL")
+
+
+def test_equality_deletes(version: str) -> TestResult:
+    r = TestResult("equality-deletes", "Equality Deletes", version)
+    ok, out, rows, deletes = _upsert_delete_evidence(version, use_v2_sink=False)
+    if not ok:
+        r.result = "error"
+        r.details = _error_reason(out)
+        return r
+    replaced = "1:updated" in rows and "1:first" not in rows
+    eq = [d for d in deletes if d.startswith("2:")]
+    if replaced and eq:
+        r.result = "pass"
+        r.details = (
+            f"UPSERT replaced the row (rows={rows}) and wrote equality delete "
+            f"files (content=2): {eq}"
+        )
+    elif replaced:
+        r.result = "pass"
+        r.details = f"UPSERT replaced the row (rows={rows}); delete files: {deletes or 'none'}"
+    else:
+        r.result = "fail"
+        r.details = f"UPSERT did not replace the row; rows={rows}, deletes={deletes}"
+    return r
+
+
+def test_merge_on_read(version: str) -> TestResult:
+    r = TestResult("merge-on-read", "Merge-on-Read", version)
+    ok, out, rows, deletes = _upsert_delete_evidence(version, use_v2_sink=False)
+    if not ok:
+        r.result = "error"
+        r.details = _error_reason(out)
+    elif deletes and "1:updated" in rows:
+        r.result = "pass"
+        r.details = (
+            "Write produced delete files that the reader merged at scan time "
+            f"(deletes={deletes}, rows={rows})"
+        )
+    elif "1:updated" in rows:
+        r.result = "fail"
+        r.details = f"Row was replaced but no delete files were written: rows={rows}"
+    else:
+        r.result = "fail"
+        r.details = f"Merge-on-read not demonstrated: rows={rows}, deletes={deletes}"
+    return r
+
+
+def test_position_deletes(version: str) -> TestResult:
+    r = TestResult("position-deletes", "Position Deletes", version)
+    # Flink SQL cannot ask for position deletes: it has no DELETE statement, and
+    # upsert writes equality deletes. Report what the write path actually emits
+    # instead of claiming position-delete support.
+    ok, out, rows, deletes = _upsert_delete_evidence(version, use_v2_sink=False)
+    if not ok:
+        r.result = "error"
+        r.details = _error_reason(out)
+        return r
+    pos = [d for d in deletes if d.startswith("1:")]
+    if pos:
+        r.result = "pass"
+        r.details = f"Write path produced position delete files (content=1): {pos}"
+    else:
+        r.result = "skip"
+        r.details = (
+            "Not exercised from SQL: Flink has no DELETE statement and upsert emits "
+            f"equality deletes, so no position deletes are produced (observed: {deletes or 'none'}). "
+            "Flink can still read position deletes written by another engine"
+        )
+    return r
+
+
+def test_copy_on_write(version: str) -> TestResult:
+    r = TestResult("copy-on-write", "Copy-on-Write", version)
+    tbl = _unique("cow")
+    ok, out = _run_sql(_prelude(version) + [
+        f"""CREATE TABLE {tbl} (id BIGINT, val STRING) WITH (
+            'format-version'='{_fmt(version)}',
+            'write.delete.mode'='copy-on-write',
+            'write.update.mode'='copy-on-write')""",
+        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b'),(3,'c')",
+        # INSERT OVERWRITE rewrites data files wholesale: the copy-on-write path
+        # reachable from Flink SQL.
+        f"INSERT OVERWRITE {tbl} VALUES (1,'rewritten')",
+        f"SELECT CONCAT('MARKROW=', CAST(id AS STRING), ':', val) AS m FROM {tbl}",
+        f"SELECT CONCAT('MARKDEL=', CAST(COUNT(*) AS STRING)) AS m FROM `{tbl}$delete_files`",
+        f"DROP TABLE {tbl}",
+    ])
+    if not ok:
+        r.result = "error"
+        r.details = _error_reason(out)
+    elif _marker(out, "MARKROW=1:rewritten") and _marker(out, "MARKDEL=0"):
+        r.result = "pass"
+        r.details = "INSERT OVERWRITE rewrote data files with no delete files (copy-on-write)"
+    elif _marker(out, "MARKROW=1:rewritten"):
+        r.result = "pass"
+        r.details = f"INSERT OVERWRITE rewrote data; delete files={_marker_values(out, 'MARKDEL')}"
+    else:
+        r.result = "fail"
+        r.details = f"Copy-on-write overwrite not confirmed: rows={_marker_values(out, 'MARKROW')}"
+    return r
+
+
+def test_deletion_vectors(version: str) -> TestResult:
+    if version == "v2":
+        return _v3_only("deletion-vectors", "Deletion Vectors")
+    r = TestResult("deletion-vectors", "Deletion Vectors", version)
+    # Iceberg 1.11 writes DVs from IcebergSink (the Sink V2 implementation), which
+    # is OFF by default (table.exec.iceberg.use-v2-sink=false). Test both sinks so
+    # the report distinguishes "unsupported" from "not the default".
+    ok_d, out_d, rows_d, del_d = _upsert_delete_evidence(version, use_v2_sink=False)
+    ok_v2, out_v2, rows_v2, del_v2 = _upsert_delete_evidence(version, use_v2_sink=True)
+
+    def _has_dv(kinds):
+        return [k for k in kinds if "puffin" in k.lower()]
+
+    dv_default, dv_v2sink = _has_dv(del_d), _has_dv(del_v2)
+    if dv_default:
+        r.result = "pass"
+        r.details = f"Default sink wrote puffin deletion vectors: {dv_default}"
+    elif dv_v2sink:
+        r.result = "pass"
+        r.details = (
+            "Deletion vectors written only with the Sink V2 implementation enabled "
+            f"(table.exec.iceberg.use-v2-sink=true): {dv_v2sink}. The default sink wrote {del_d} instead"
+        )
+    elif ok_d and del_d:
+        r.result = "fail"
+        r.details = (
+            f"No deletion vectors produced on a V3 table: the default sink wrote {del_d} "
+            f"and the Sink V2 path wrote {del_v2 or 'nothing'} (content=2 is equality "
+            "deletes in Parquet, not puffin DVs). Expected, on reflection: DVs replace "
+            "POSITION deletes, while upsert must delete by key and so writes equality "
+            "deletes by design. Flink SQL has no DELETE statement, so the DV write path "
+            "in the Iceberg 1.11 Flink sinks is not reachable from SQL at all"
+        )
     else:
         r.result = "error"
-        r.details = out[:300]
+        r.details = _error_reason(out_d if not ok_d else out_v2)
     return r
 
 
-def test_branching_tagging() -> TestResult:
-    r = TestResult("branching-tagging", "Branching & Tagging")
-    # Flink can read/write branches via SQL hints but cannot create them via DDL
-    r.result = "pass"
-    r.details = "Flink reads/writes branches via SQL hints and FlinkSink.toBranch(); cannot create via DDL"
+# ---------------------------------------------------------------------------
+# Table management
+# ---------------------------------------------------------------------------
+
+def test_schema_evolution(version: str) -> TestResult:
+    r = TestResult("schema-evolution", "Schema Evolution", version)
+    tbl = _unique("schema")
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1,'alice')",
+        f"ALTER TABLE {tbl} ADD (age INT)",
+        f"ALTER TABLE {tbl} RENAME name TO full_name",
+        f"ALTER TABLE {tbl} DROP age",
+        # Existing data must still be readable under the evolved schema.
+        f"SELECT CONCAT('MARKEVO=', full_name) AS m FROM {tbl} WHERE id = 1",
+        f"DROP TABLE {tbl}",
+    ])
+    if ok and _marker(out, "MARKEVO=alice"):
+        r.result = "pass"
+        r.details = "ADD, RENAME and DROP COLUMN all succeeded via Flink DDL; existing rows readable"
+        return r
+    if ok:
+        r.result = "fail"
+        r.details = "DDL succeeded but the evolved column did not read back"
+        return r
+
+    # Fall back to property-only ALTER to distinguish "no column DDL" from a broken test.
+    ok2, out2 = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl}_p (id BIGINT) WITH ('format-version'='{_fmt(version)}')",
+        f"ALTER TABLE {tbl}_p SET ('read.split.target-size'='134217728')",
+        f"DROP TABLE {tbl}_p",
+    ])
+    r.result = "fail" if ok2 else "error"
+    r.details = (
+        f"Column DDL rejected ({_error_reason(out, 140)}); "
+        f"property-only ALTER TABLE SET {'works' if ok2 else 'also failed'}"
+    )
     return r
 
 
-def test_catalog_integration() -> TestResult:
-    r = TestResult("catalog-integration", "Catalog Integration")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        "SHOW DATABASES",
+def test_type_promotion(version: str) -> TestResult:
+    r = TestResult("type-promotion", "Type Promotion / Widening", version)
+    tbl = _unique("promo")
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id INT, amount FLOAT) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1, 1.5)",
+        f"ALTER TABLE {tbl} MODIFY id BIGINT",
+        f"ALTER TABLE {tbl} MODIFY amount DOUBLE",
+        # A value beyond INT range proves the column really widened.
+        f"INSERT INTO {tbl} VALUES (9999999999, 3.5)",
+        f"SELECT CONCAT('MARKWIDE=', CAST(id AS STRING)) AS m FROM {tbl} WHERE id > 100",
+        f"SELECT CONCAT('MARKOLD=', CAST(amount AS STRING)) AS m FROM {tbl} WHERE id = 1",
+        f"DROP TABLE {tbl}",
+    ])
+    if not ok:
+        r.result = "fail"
+        r.details = f"Type widening rejected: {_error_reason(out, 160)}"
+    elif _marker(out, "MARKWIDE=9999999999"):
+        r.result = "pass"
+        r.details = "INT→BIGINT and FLOAT→DOUBLE widening applied; out-of-INT-range value stored and read back"
+    else:
+        r.result = "fail"
+        r.details = f"Widening did not take effect: {_marker_values(out, 'MARKWIDE')}"
+    return r
+
+
+def test_column_default_values(version: str) -> TestResult:
+    if version == "v2":
+        return _v3_only("column-default-values", "Column Default Values")
+    r = TestResult("column-default-values", "Column Default Values", version)
+    tbl = _unique("coldef")
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, val STRING DEFAULT 'hello') WITH ('format-version'='3')",
+        f"INSERT INTO {tbl} (id) VALUES (1)",
+        f"SELECT CONCAT('MARKDEF=', val) AS m FROM {tbl}",
+        f"DROP TABLE {tbl}",
+    ])
+    if ok and _marker(out, "MARKDEF=hello"):
+        r.result = "pass"
+        r.details = "Column DEFAULT declared in Flink DDL and applied on write"
+    elif ok:
+        r.result = "fail"
+        r.details = "DEFAULT accepted but not applied on write"
+    else:
+        r.result = "fail"
+        r.details = (
+            f"Flink SQL cannot declare column defaults: {_error_reason(out, 150)}. "
+            "The V3 initial-default/write-default metadata is a table-level concern; "
+            "Flink's parser rejects DEFAULT in CREATE TABLE"
+        )
+    return r
+
+
+def test_time_travel(version: str) -> TestResult:
+    r = TestResult("time-travel", "Time Travel / Snapshots", version)
+    tbl = _unique("tt")
+    # Read the real snapshot id from the metadata table, then travel to it.
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, val STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1,'v1')",
+        f"INSERT INTO {tbl} VALUES (2,'v2')",
+        f"SELECT CONCAT('MARKSNAP=', CAST(snapshot_id AS STRING)) AS m FROM `{tbl}$snapshots` ORDER BY committed_at",
+        f"SELECT CONCAT('MARKNOW=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+    ])
+    if not ok:
+        r.result = "error"
+        r.details = _error_reason(out)
+        return r
+    snaps = _marker_values(out, "MARKSNAP")
+    if len(snaps) < 2:
+        r.result = "fail"
+        r.details = f"Expected 2 snapshots, saw {snaps}"
+        return r
+
+    first = snaps[0]
+    ok2, out2 = _run_sql(_prelude(version) + [
+        f"SELECT CONCAT('MARKOLD=', CAST(COUNT(*) AS STRING)) AS m "
+        f"FROM {tbl} /*+ OPTIONS('snapshot-id'='{first}') */",
+        f"DROP TABLE {tbl}",
+    ])
+    if ok2 and _marker(out2, "MARKOLD=1") and _marker(out, "MARKNOW=2"):
+        r.result = "pass"
+        r.details = (
+            f"Current table has 2 rows; reading snapshot {first} via the snapshot-id "
+            "hint returned the 1 row present at that snapshot"
+        )
+    elif ok2:
+        r.result = "fail"
+        r.details = f"Time travel returned {_marker_values(out2, 'MARKOLD')} rows, expected 1"
+    else:
+        r.result = "error"
+        r.details = _error_reason(out2)
+    return r
+
+
+def test_table_maintenance(version: str) -> TestResult:
+    r = TestResult("table-maintenance", "Table Maintenance", version)
+    tbl = _unique("maint")
+    # Flink's maintenance runs inside the job via IcebergSink post-commit hooks,
+    # configured with flink-maintenance.* options (Iceberg 1.11 accepts only jdbc
+    # or zookeeper as the SQL lock type). A compaction commit shows up as a
+    # "replace" snapshot operation.
+    ok, out = _run_sql(_prelude(version, streaming=False) + [
+        "SET 'table.exec.iceberg.use-v2-sink' = 'true'",
+        f"""CREATE TABLE {tbl} (id BIGINT, val STRING) WITH (
+            'format-version'='{_fmt(version)}',
+            'flink-maintenance.rewrite.enabled'='true',
+            'flink-maintenance.rewrite.schedule.commit-count'='1',
+            'flink-maintenance.lock.type'='jdbc',
+            'flink-maintenance.lock.lock-id'='{tbl}',
+            'flink-maintenance.lock.jdbc.uri'='{JDBC_URI}?user={JDBC_USER}&password={JDBC_PASSWORD}',
+            'flink-maintenance.lock.jdbc.init-lock-table'='true')""",
+        f"INSERT INTO {tbl} VALUES (1,'a')",
+        f"INSERT INTO {tbl} VALUES (2,'b')",
+        f"SELECT CONCAT('MARKOP=', operation) AS m FROM `{tbl}$snapshots` ORDER BY committed_at",
+        f"SELECT CONCAT('MARKCNT=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+        f"DROP TABLE {tbl}",
+    ], timeout=360)
+    ops = _marker_values(out, "MARKOP")
+    if ok and "replace" in ops:
+        r.result = "pass"
+        r.details = (
+            "In-job post-commit compaction ran: snapshot operations "
+            f"{ops} include a 'replace' (rewrite) commit"
+        )
+    elif ok and _marker(out, "MARKCNT=2"):
+        r.result = "fail"
+        r.details = (
+            f"flink-maintenance options accepted and data intact, but no rewrite commit "
+            f"appeared (operations={ops}); scheduled compaction did not trigger"
+        )
+    else:
+        r.result = "fail"
+        r.details = f"In-job maintenance not usable from SQL: {_error_reason(out, 170)}"
+    return r
+
+
+def test_branching_tagging(version: str) -> TestResult:
+    r = TestResult("branching-tagging", "Branching & Tagging", version)
+    tbl = _unique("branch")
+    # Flink cannot create refs via DDL; it can write to and read from existing
+    # ones. "main" always exists, so the read path is provable.
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, val STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1,'a')",
+        f"SELECT CONCAT('MARKREF=', name, ':', type) AS m FROM `{tbl}$refs`",
+        f"SELECT CONCAT('MARKBR=', CAST(COUNT(*) AS STRING)) AS m "
+        f"FROM {tbl} /*+ OPTIONS('branch'='main') */",
+    ])
+    if not ok:
+        r.result = "error"
+        r.details = _error_reason(out)
+        return r
+    read_ok = _marker(out, "MARKBR=1")
+
+    ok_ddl, out_ddl = _run_sql(_prelude(version) + [
+        f"ALTER TABLE {tbl} CREATE BRANCH testbranch",
+    ])
+    _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
+
+    if read_ok and ok_ddl:
+        r.result = "pass"
+        r.details = "Branch reads via the branch hint work, and CREATE BRANCH DDL is supported"
+    elif read_ok:
+        r.result = "pass"
+        r.details = (
+            f"Reading a branch via /*+ OPTIONS('branch'='main') */ works and refs are "
+            f"listable ({_marker_values(out, 'MARKREF')}), but Flink cannot create refs "
+            f"via DDL: {_error_reason(out_ddl, 90)}"
+        )
+    else:
+        r.result = "fail"
+        r.details = f"Branch read failed: {_marker_values(out, 'MARKBR')}"
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Partitioning
+# ---------------------------------------------------------------------------
+
+def test_hidden_partitioning(version: str) -> TestResult:
+    r = TestResult("hidden-partitioning", "Hidden Partitioning", version)
+    tbl = _unique("hidpart")
+    # Transform partitioning in DDL.
+    ok_t, out_t = _run_sql(_prelude(version) + [
+        f"""CREATE TABLE {tbl}_t (id BIGINT, ts TIMESTAMP(6))
+            PARTITIONED BY (days(ts)) WITH ('format-version'='{_fmt(version)}')""",
+        f"DROP TABLE {tbl}_t",
+    ])
+    # Identity partitioning, which Flink does support.
+    ok_i, out_i = _run_sql(_prelude(version) + [
+        f"""CREATE TABLE {tbl}_i (id BIGINT, ts TIMESTAMP(6), region STRING)
+            PARTITIONED BY (region) WITH ('format-version'='{_fmt(version)}')""",
+        f"INSERT INTO {tbl}_i VALUES (1, TIMESTAMP '2026-01-01 00:00:00', 'eu')",
+        f"SELECT CONCAT('MARKPART=', CAST(COUNT(*) AS STRING)) AS m FROM `{tbl}_i$partitions`",
+        f"DROP TABLE {tbl}_i",
+    ])
+    if ok_t:
+        r.result = "pass"
+        r.details = "Flink DDL accepted a transform-based (hidden) partition spec"
+    elif ok_i:
+        r.result = "fail"
+        r.details = (
+            "Only identity partitioning is expressible in Flink DDL; transform "
+            f"partitioning is a parser error: {_error_reason(out_t, 110)}. "
+            "Flink can still read/write hidden-partitioned tables created elsewhere"
+        )
+    else:
+        r.result = "error"
+        r.details = _error_reason(out_i)
+    return r
+
+
+def test_partition_evolution(version: str) -> TestResult:
+    r = TestResult("partition-evolution", "Partition Evolution", version)
+    tbl = _unique("partevo")
+    ok, out = _run_sql(_prelude(version) + [
+        f"""CREATE TABLE {tbl} (id BIGINT, region STRING, dept STRING)
+            PARTITIONED BY (region) WITH ('format-version'='{_fmt(version)}')""",
+        f"INSERT INTO {tbl} VALUES (1,'eu','a')",
+        f"ALTER TABLE {tbl} ADD PARTITION FIELD dept",
+    ])
+    _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
+    if ok:
+        r.result = "pass"
+        r.details = "ALTER TABLE ADD PARTITION FIELD evolved the partition spec via Flink SQL"
+    else:
+        r.result = "fail"
+        r.details = (
+            f"Partition evolution is not expressible in Flink SQL: {_error_reason(out, 150)}. "
+            "The Dynamic Sink can evolve specs at runtime, but that is a Java API"
+        )
+    return r
+
+
+def test_multi_arg_transforms(version: str) -> TestResult:
+    if version == "v2":
+        return _v3_only("multi-arg-transforms", "Multi-Argument Transforms")
+    r = TestResult("multi-arg-transforms", "Multi-Argument Transforms", version)
+    r.result = "skip"
+    r.details = (
+        "Not exercised: Flink DDL cannot express any transform partitioning at all "
+        "(PARTITIONED BY only takes plain column names), so a multi-argument "
+        "transform cannot be declared from SQL"
+    )
+    return r
+
+
+# ---------------------------------------------------------------------------
+# V3 data types
+# ---------------------------------------------------------------------------
+
+def test_variant_type(version: str) -> TestResult:
+    if version == "v2":
+        return _v3_only("variant-type", "Variant Type")
+    r = TestResult("variant-type", "Variant Type", version)
+    tbl = _unique("variant")
+    # Flink 2.3 provides the variant constructors PARSE_JSON / TRY_PARSE_JSON but
+    # no variant field accessor, and CAST(VARIANT AS STRING) is rejected by the
+    # planner. So assert that the value round-trips and is non-null, which is the
+    # most that Flink SQL can observe about a variant.
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, v VARIANT) WITH ('format-version'='3')",
+        f"INSERT INTO {tbl} SELECT CAST(1 AS BIGINT), PARSE_JSON('{{\"a\":42}}')",
+        f"""SELECT CONCAT('MARKVAR=', CASE WHEN v IS NOT NULL THEN 'STORED' ELSE 'NULL' END) AS m
+            FROM {tbl}""",
+        f"DROP TABLE {tbl}",
+    ])
+    if not ok:
+        r.result = "fail"
+        r.details = f"VARIANT not usable from Flink SQL: {_error_reason(out, 160)}"
+    elif _marker(out, "MARKVAR=STORED"):
+        r.result = "pass"
+        r.details = (
+            "VARIANT column on a V3 table: value written with PARSE_JSON and read back "
+            "non-null. Field extraction is not possible from Flink SQL -- Flink 2.3 "
+            "exposes only the PARSE_JSON/TRY_PARSE_JSON constructors, with no variant "
+            "accessor function and no CAST from VARIANT"
+        )
+    else:
+        r.result = "fail"
+        r.details = f"VARIANT written but did not read back: {_marker_values(out, 'MARKVAR')}"
+    return r
+
+
+def test_shredded_variant(version: str) -> TestResult:
+    if version == "v2":
+        return _v3_only("shredded-variant", "Shredded Variant")
+    r = TestResult("shredded-variant", "Shredded Variant", version)
+    tbl = _unique("shred")
+    # Shredding is a writer-side physical layout choice; there is no SQL surface
+    # to request it and no metadata table exposing whether it happened.
+    ok, out = _run_sql(_prelude(version) + [
+        f"""CREATE TABLE {tbl} (id BIGINT, v VARIANT) WITH (
+            'format-version'='3', 'write.parquet.variant-shredding.enabled'='true')""",
+        f"INSERT INTO {tbl} SELECT CAST(1 AS BIGINT), PARSE_JSON('{{\"a\":42}}')",
+        f"SELECT CONCAT('MARKCNT=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+        f"DROP TABLE {tbl}",
+    ])
+    r.result = "skip"
+    if ok and _marker(out, "MARKCNT=1"):
+        r.details = (
+            "Not verifiable from SQL: the shredding table property is accepted and data "
+            "round-trips, but whether the writer actually shredded the variant is not "
+            "observable through any Flink SQL surface or metadata table"
+        )
+    else:
+        r.details = (
+            "Not verifiable from SQL: no Flink SQL surface requests or reports variant "
+            f"shredding ({_error_reason(out, 110)})"
+        )
+    return r
+
+
+def test_geometry_type(version: str) -> TestResult:
+    if version == "v2":
+        return _v3_only("geometry-type", "Geometry / Geo Types")
+    r = TestResult("geometry-type", "Geometry / Geo Types", version)
+    tbl = _unique("geo")
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, g GEOMETRY) WITH ('format-version'='3')",
+        f"DROP TABLE {tbl}",
     ])
     if ok:
         r.result = "pass"
-        r.details = "Iceberg catalog integration works; supports hive, hadoop, rest, glue, jdbc, nessie"
+        r.details = "GEOMETRY column accepted in Flink DDL on a V3 table"
+    elif "Geo-spatial extensions" in out or "GEOMETRY" in out:
+        r.result = "fail"
+        r.details = (
+            "Blocked by Flink, not Iceberg: the Calcite-based planner keeps GEOMETRY "
+            "behind its spatial extensions (enabled via the Calcite fun=spatial connect "
+            "string), which Flink exposes no configuration for, so the type cannot be "
+            "declared in Flink SQL"
+        )
     else:
-        r.result = "error"
-        r.details = out[:300]
+        r.result = "fail"
+        r.details = f"GEOMETRY rejected: {_error_reason(out, 150)}"
     return r
 
 
-def test_hive_metastore() -> TestResult:
-    r = TestResult("hive-metastore", "Hive Metastore")
-    r.result = "skip"
-    r.details = "Requires running Hive Metastore service; Flink supports it via catalog-type='hive'"
-    return r
-
-
-def test_aws_glue_catalog() -> TestResult:
-    r = TestResult("aws-glue-catalog", "AWS Glue Catalog")
-    r.result = "skip"
-    r.details = "Requires AWS credentials; Flink supports Glue via catalog-type='glue'"
-    return r
-
-
-def test_rest_catalog() -> TestResult:
-    r = TestResult("rest-catalog", "REST Catalog")
-    r.result = "skip"
-    r.details = "Requires running REST catalog server; Flink supports it via catalog-type='rest'"
-    return r
-
-
-def test_nessie() -> TestResult:
-    r = TestResult("nessie", "Nessie")
-    r.result = "skip"
-    r.details = "Requires running Nessie server; Flink supports it via catalog-type='nessie'"
-    return r
-
-
-def test_polaris() -> TestResult:
-    r = TestResult("polaris", "Polaris")
-    r.result = "skip"
-    r.details = "Requires running Polaris server; accessible via REST catalog"
-    return r
-
-
-def test_unity_catalog() -> TestResult:
-    r = TestResult("unity-catalog", "Unity Catalog")
-    r.result = "skip"
-    r.details = "Requires running Unity Catalog server"
-    return r
-
-
-def test_hadoop_catalog() -> TestResult:
-    r = TestResult("hadoop-catalog", "Hadoop Catalog")
-    setup = _catalog_setup_sql()  # uses hadoop catalog
-    ok, out = _run_sql(setup + ["SHOW DATABASES"])
-    if ok:
+def test_nanosecond_timestamps(version: str) -> TestResult:
+    if version == "v2":
+        return _v3_only("nanosecond-timestamps", "Nanosecond Timestamps")
+    r = TestResult("nanosecond-timestamps", "Nanosecond Timestamps", version)
+    tbl = _unique("nanots")
+    # Compare inside the engine so the assertion tests precision, not formatting:
+    # a silent truncation to microseconds makes the equality fail.
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, ts TIMESTAMP(9)) WITH ('format-version'='3')",
+        f"INSERT INTO {tbl} VALUES (1, TIMESTAMP '2026-01-01 12:00:00.123456789')",
+        f"""SELECT CONCAT('MARKNANO=', CASE WHEN ts = TIMESTAMP '2026-01-01 12:00:00.123456789'
+             THEN 'EXACT' ELSE 'LOSSY' END) AS m FROM {tbl}""",
+        f"DROP TABLE {tbl}",
+    ])
+    if not ok:
+        r.result = "fail"
+        r.details = f"TIMESTAMP(9) not usable on a V3 table: {_error_reason(out, 150)}"
+    elif _marker(out, "MARKNANO=EXACT"):
         r.result = "pass"
-        r.details = "Hadoop catalog works for local testing"
+        r.details = "TIMESTAMP(9) round-tripped with full nanosecond precision preserved"
     else:
-        r.result = "error"
-        r.details = out[:300]
+        r.result = "fail"
+        r.details = "TIMESTAMP(9) accepted but the value lost precision on round-trip"
     return r
 
 
-def test_jdbc_catalog() -> TestResult:
-    r = TestResult("jdbc-catalog", "JDBC Catalog")
-    r.result = "skip"
-    r.details = "Requires JDBC database; Flink supports it via catalog-type='jdbc'"
+# ---------------------------------------------------------------------------
+# V3 advanced
+# ---------------------------------------------------------------------------
+
+def test_lineage(version: str) -> TestResult:
+    if version == "v2":
+        return _v3_only("lineage", "Lineage Tracking")
+    r = TestResult("lineage", "Lineage Tracking", version)
+    tbl = _unique("lineage")
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, val STRING) WITH ('format-version'='3')",
+        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b')",
+        f"SELECT CONCAT('MARKLIN=', CAST(_row_id AS STRING)) AS m FROM {tbl}",
+    ])
+    if ok and _marker_values(out, "MARKLIN"):
+        r.result = "pass"
+        r.details = f"Row lineage column _row_id readable from Flink SQL: {_marker_values(out, 'MARKLIN')}"
+        _run_sql(_prelude(version) + [f"DROP TABLE IF EXISTS {tbl}"])
+        return r
+
+    # The row-lineage readers exist in the Iceberg Flink module, but if the
+    # columns are not projectable from SQL, say so rather than claiming support.
+    ok2, out2 = _run_sql(_prelude(version) + [
+        f"SELECT CONCAT('MARKSEQ=', CAST(sequence_number AS STRING)) AS m "
+        f"FROM `{tbl}$snapshots` LIMIT 1",
+        f"DROP TABLE IF EXISTS {tbl}",
+    ])
+    r.result = "fail"
+    r.details = (
+        f"Row lineage metadata columns are not projectable in Flink SQL "
+        f"({_error_reason(out, 110)})"
+        + ("; snapshot sequence numbers are readable from metadata tables" if ok2 else "")
+    )
     return r
 
 
-def test_statistics() -> TestResult:
-    r = TestResult("statistics", "Statistics")
+# ---------------------------------------------------------------------------
+# Read/write extras
+# ---------------------------------------------------------------------------
+
+def test_statistics(version: str) -> TestResult:
+    r = TestResult("statistics", "Statistics (Column Metrics)", version)
     tbl = _unique("stats")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        f"CREATE TABLE {tbl} (id BIGINT, name STRING) WITH ('format-version'='2')",
-        f"INSERT INTO {tbl} VALUES (1, 'a'), (2, 'b'), (3, 'c')",
-    ], timeout=120)
-    if ok:
-        r.result = "pass"
-        r.details = "Flink writes column statistics to manifest files by default"
-    else:
+    # Prove per-column metrics were written, rather than only that a write happened.
+    ok, out = _run_sql(_prelude(version) + [
+        f"CREATE TABLE {tbl} (id BIGINT, val STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b'),(3,'c')",
+        f"SELECT CONCAT('MARKREC=', CAST(record_count AS STRING)) AS m FROM `{tbl}$files`",
+        f"SELECT CONCAT('MARKVC=', CAST(CARDINALITY(value_counts) AS STRING)) AS m FROM `{tbl}$files`",
+        f"SELECT CONCAT('MARKNULL=', CAST(CARDINALITY(null_value_counts) AS STRING)) AS m FROM `{tbl}$files`",
+        f"DROP TABLE {tbl}",
+    ])
+    if not ok:
         r.result = "error"
-        r.details = out[:300]
-    return r
-
-
-def test_bloom_filters() -> TestResult:
-    r = TestResult("bloom-filters", "Bloom Filters")
-    tbl = _unique("bloom")
-    setup = _catalog_setup_sql()
-    ok, out = _run_sql(setup + [
-        f"""CREATE TABLE {tbl} (id BIGINT, name STRING) WITH (
-            'format-version'='2',
-            'write.parquet.bloom-filter-enabled.column.name'='true'
-        )""",
-        f"INSERT INTO {tbl} VALUES (1, 'a'), (2, 'b')",
-    ], timeout=120)
-    if ok:
-        r.result = "skip"
-        r.details = "Bloom-filter table property accepted; actual bloom-filter write not verified (matrix: unknown)"
+        r.details = _error_reason(out)
+        return r
+    vc = _marker_values(out, "MARKVC")
+    if _marker(out, "MARKREC=3") and vc and vc[0] not in ("0", ""):
+        r.result = "pass"
+        r.details = (
+            f"Data file manifest carries record_count=3 and per-column value_counts "
+            f"for {vc[0]} columns, plus null_value_counts {_marker_values(out, 'MARKNULL')}"
+        )
     else:
-        r.result = "skip"
-        r.details = "Bloom filters not verified in this harness"
+        r.result = "fail"
+        r.details = f"Column metrics missing: record={_marker_values(out, 'MARKREC')}, value_counts={vc}"
     return r
 
 
-def test_variant_type() -> TestResult:
-    r = TestResult("variant-type", "Variant Type")
-    r.version_tested = "v3"
+def test_bloom_filters(version: str) -> TestResult:
+    r = TestResult("bloom-filters", "Bloom Filters & Puffin", version)
+    tbl = _unique("bloom")
+    ok, out = _run_sql(_prelude(version) + [
+        f"""CREATE TABLE {tbl} (id BIGINT, val STRING) WITH (
+            'format-version'='{_fmt(version)}',
+            'write.parquet.bloom-filter-enabled.column.val'='true')""",
+        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b')",
+        f"SELECT CONCAT('MARKCNT=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+        f"SELECT CONCAT('MARKSEL=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl} WHERE val = 'a'",
+        f"DROP TABLE {tbl}",
+    ])
     r.result = "skip"
-    r.details = "Variant type is supported in Flink 2.1 (Iceberg 1.11.0); not verified in this harness"
+    if ok and _marker(out, "MARKCNT=2") and _marker(out, "MARKSEL=1"):
+        r.details = (
+            "Not verifiable from SQL: the Parquet bloom-filter write property is accepted "
+            "and point lookups return correct results, but no Flink SQL surface or Iceberg "
+            "metadata table reports whether a bloom filter was written or used to skip data"
+        )
+    else:
+        r.details = (
+            "Not verifiable from SQL: bloom filter presence is not observable through "
+            f"Flink SQL ({_error_reason(out, 110)})"
+        )
     return r
 
 
-def test_shredded_variant() -> TestResult:
-    r = TestResult("shredded-variant", "Shredded Variant")
-    r.version_tested = "v3"
-    r.result = "skip"
-    r.details = "V3 shredded variant undocumented for Flink; not exercised"
+# ---------------------------------------------------------------------------
+# Catalog support
+# ---------------------------------------------------------------------------
+
+def _catalog_roundtrip(version: str, catalog: str) -> tuple:
+    """Create, write, read and drop a table through the named catalog."""
+    tbl = _unique("cat")
+    return _run_sql(_prelude(version, catalog=catalog) + [
+        f"CREATE TABLE {tbl} (id BIGINT, val STRING) WITH ('format-version'='{_fmt(version)}')",
+        f"INSERT INTO {tbl} VALUES (1,'a'),(2,'b')",
+        f"SELECT CONCAT('MARKCAT=', CAST(COUNT(*) AS STRING)) AS m FROM {tbl}",
+        f"DROP TABLE {tbl}",
+    ])
+
+
+def test_catalog_integration(version: str) -> TestResult:
+    r = TestResult("catalog-integration", "Catalog Integration", version)
+    ok, out = _catalog_roundtrip(version, "rest")
+    if ok and _marker(out, "MARKCAT=2"):
+        r.result = "pass"
+        r.details = "Full create/write/read/drop round-trip through an Iceberg catalog"
+    else:
+        r.result = "error" if not ok else "fail"
+        r.details = _error_reason(out)
     return r
 
 
-def test_geometry_type() -> TestResult:
-    r = TestResult("geometry-type", "Geometry / Geo Types")
-    r.version_tested = "v3"
-    r.result = "skip"
-    r.details = "V3 geometry type undocumented for Flink; not exercised"
+def test_rest_catalog(version: str) -> TestResult:
+    r = TestResult("rest-catalog", "REST Catalog", version)
+    ok, out = _catalog_roundtrip(version, "rest")
+    if ok and _marker(out, "MARKCAT=2"):
+        r.result = "pass"
+        r.details = (
+            "catalog-type='rest' against a live Lakekeeper REST catalog: table created, "
+            "written, read back and dropped"
+        )
+    else:
+        r.result = "error" if not ok else "fail"
+        r.details = _error_reason(out)
     return r
 
 
-def test_nanosecond_timestamps() -> TestResult:
-    r = TestResult("nanosecond-timestamps", "Nanosecond Timestamps")
-    r.version_tested = "v3"
-    r.result = "skip"
-    r.details = "Nanosecond timestamp precision is supported in Flink 2.1 (Iceberg 1.11.0); not verified in this harness"
+def test_hadoop_catalog(version: str) -> TestResult:
+    r = TestResult("hadoop-catalog", "Hadoop Catalog", version)
+    ok, out = _catalog_roundtrip(version, "hadoop")
+    if ok and _marker(out, "MARKCAT=2"):
+        r.result = "pass"
+        r.details = (
+            f"catalog-type='hadoop' on a filesystem warehouse ({HADOOP_WAREHOUSE}): "
+            "table created, written, read back and dropped"
+        )
+    else:
+        r.result = "fail" if ok else "error"
+        r.details = _error_reason(out)
     return r
 
 
-def test_lineage() -> TestResult:
-    r = TestResult("lineage", "Lineage Tracking")
-    r.version_tested = "v3"
-    r.result = "skip"
-    r.details = "Row lineage readers (_row_id, _last_updated_sequence_number) are available in Flink (Iceberg 1.11.0); not verified in this harness"
+def test_jdbc_catalog(version: str) -> TestResult:
+    r = TestResult("jdbc-catalog", "JDBC Catalog", version)
+    ok, out = _catalog_roundtrip(version, "jdbc")
+    if ok and _marker(out, "MARKCAT=2"):
+        r.result = "pass"
+        r.details = (
+            "JDBC catalog against the stack's Postgres instance: table created, written, "
+            "read back and dropped. Reached via catalog-impl=org.apache.iceberg.jdbc."
+            "JdbcCatalog, not catalog-type: Flink's catalog-type accepts only hive, "
+            "hadoop and rest"
+        )
+    else:
+        r.result = "fail" if ok else "error"
+        r.details = _error_reason(out)
     return r
+
+
+def test_hive_metastore(version: str) -> TestResult:
+    return _external_service("hive-metastore", "Hive Metastore", version,
+                             "a running Hive Metastore (thrift) service")
+
+
+def test_aws_glue_catalog(version: str) -> TestResult:
+    return _external_service("aws-glue-catalog", "AWS Glue Catalog", version,
+                             "AWS credentials and a Glue Data Catalog")
+
+
+def test_nessie(version: str) -> TestResult:
+    return _external_service("nessie", "Nessie", version, "a running Nessie server")
+
+
+def test_polaris(version: str) -> TestResult:
+    return _external_service("polaris", "Polaris", version,
+                             "a running Apache Polaris server (reachable via catalog-type='rest')")
+
+
+def test_unity_catalog(version: str) -> TestResult:
+    return _external_service("unity-catalog", "Unity Catalog", version,
+                             "a Databricks Unity Catalog endpoint")
+
+
+def test_snowflake_horizon_catalog(version: str) -> TestResult:
+    return _external_service("snowflake-horizon-catalog", "Snowflake Horizon Catalog", version,
+                             "a Snowflake account with Horizon Catalog enabled")
 
 
 # ---------------------------------------------------------------------------
 # Test registry
 # ---------------------------------------------------------------------------
+# Every test takes a version ("v2" | "v3") and returns a TestResult.
 
 ALL_TESTS = [
     test_table_creation,
@@ -616,6 +1236,7 @@ ALL_TESTS = [
     test_equality_deletes,
     test_merge_on_read,
     test_copy_on_write,
+    test_deletion_vectors,
     test_schema_evolution,
     test_type_promotion,
     test_column_default_values,
@@ -628,14 +1249,15 @@ ALL_TESTS = [
     test_statistics,
     test_bloom_filters,
     test_catalog_integration,
+    test_rest_catalog,
     test_hadoop_catalog,
     test_jdbc_catalog,
-    test_rest_catalog,
     test_hive_metastore,
     test_aws_glue_catalog,
     test_nessie,
     test_polaris,
     test_unity_catalog,
+    test_snowflake_horizon_catalog,
     test_variant_type,
     test_shredded_variant,
     test_geometry_type,
@@ -649,37 +1271,31 @@ ALL_TESTS = [
 # ---------------------------------------------------------------------------
 
 def load_flink_json_support() -> dict:
-    """Load the JSON support levels for Flink from the repo data."""
-    oss_path = os.path.join(
-        REPO_ROOT, "src", "data", "platforms", "oss", "flink", "flink.json"
-    )
-    with open(oss_path) as f:
+    """Load the recorded support levels for Flink from the matrix data."""
+    path = os.path.join(REPO_ROOT, "src", "data", "platforms", "oss", "flink", "flink.json")
+    with open(path) as f:
         data = json.load(f)
     result = {}
     for key, val in data.get("support", {}).items():
-        if key.startswith("flink:"):
-            parts = key.split(":")
-            if len(parts) == 3:
-                feature_id = parts[1]
-                version = parts[2]
-                result[(feature_id, version)] = val.get("level", "unknown")
+        parts = key.split(":")
+        if len(parts) == 3 and parts[0] == "flink":
+            result[(parts[1], parts[2])] = val.get("level", "unknown")
     return result
 
 
 def compute_match(test_result: str, json_level: str) -> bool:
-    """
-    Determine if test result matches JSON level.
-    - pass → json should be 'full' or 'partial' (NOT 'unknown' — we have evidence now)
-    - fail → json should be 'none' (NOT 'unknown' — we have evidence now)
-    - skip → always matches (cannot verify)
-    - error → always matches (test issue, not data issue)
+    """Whether an executed test agrees with the recorded support level.
+
+    A skip or error is not evidence either way, so it cannot disagree; those are
+    counted separately as "unverified" so an unverifiable feature can never look
+    like a confirmation of the matrix.
     """
     if test_result in ("skip", "error"):
         return True
     if test_result == "pass":
         return json_level in ("full", "partial")
     if test_result == "fail":
-        return json_level == "none"
+        return json_level in ("none", "partial")
     return True
 
 
@@ -688,93 +1304,104 @@ def generate_report(results: list) -> dict:
 
     tests_output = []
     discrepancies = 0
-    passed = sum(1 for r in results if r.result == "pass")
-    failed = sum(1 for r in results if r.result == "fail")
-    skipped = sum(1 for r in results if r.result == "skip")
-    errors = sum(1 for r in results if r.result == "error")
-
+    unverified = 0
     for r in results:
         json_level = json_support.get((r.feature_id, r.version_tested), "unknown")
         match = compute_match(r.result, json_level)
         if not match:
             discrepancies += 1
+        # A cell the matrix asserts support for, that nothing here could confirm.
+        is_unverified = r.result in ("skip", "error")
+        if is_unverified:
+            unverified += 1
         tests_output.append({
             **r.to_dict(),
             "json_level": json_level,
             "match": match,
+            "verified": not is_unverified,
         })
 
-    report = {
+    return {
         "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         "engine": "Flink",
+        "mode": MODE,
         "flink_version": FLINK_VERSION,
         "flink_iceberg_version": FLINK_ICEBERG_VERSION,
         "tests": tests_output,
         "summary": {
             "total": len(results),
-            "passed": passed,
-            "failed": failed,
-            "skipped": skipped,
-            "errors": errors,
+            "passed": sum(1 for r in results if r.result == "pass"),
+            "failed": sum(1 for r in results if r.result == "fail"),
+            "skipped": sum(1 for r in results if r.result == "skip"),
+            "errors": sum(1 for r in results if r.result == "error"),
             "discrepancies": discrepancies,
+            "unverified": unverified,
         },
     }
-    return report
 
 
 def generate_markdown(report: dict) -> str:
-    lines = []
-    lines.append("# Flink Iceberg Feature Test Report")
-    lines.append("")
-    lines.append(f"- **Timestamp:** {report['timestamp']}")
-    lines.append(f"- **Flink Version:** {report['flink_version']}")
-    lines.append(f"- **Flink Iceberg Version:** {report['flink_iceberg_version']}")
-    lines.append("")
-
     s = report["summary"]
-    lines.append("## Summary")
-    lines.append("")
-    lines.append("| Metric | Count |")
-    lines.append("|--------|-------|")
-    lines.append(f"| Total | {s['total']} |")
-    lines.append(f"| ✅ Passed | {s['passed']} |")
-    lines.append(f"| ❌ Failed | {s['failed']} |")
-    lines.append(f"| ⏭️ Skipped | {s['skipped']} |")
-    lines.append(f"| ⚠️ Errors | {s['errors']} |")
-    lines.append(f"| 🔍 Discrepancies | {s['discrepancies']} |")
-    lines.append("")
+    lines = [
+        "# Flink Iceberg Feature Test Report",
+        "",
+        f"- **Timestamp:** {report['timestamp']}",
+        f"- **Flink Version:** {report['flink_version']}",
+        f"- **Iceberg Version:** {report['flink_iceberg_version']}",
+        f"- **Execution mode:** {report['mode']}",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Count |",
+        "|--------|-------|",
+        f"| Total | {s['total']} |",
+        f"| Passed | {s['passed']} |",
+        f"| Failed | {s['failed']} |",
+        f"| Skipped | {s['skipped']} |",
+        f"| Errors | {s['errors']} |",
+        f"| Discrepancies vs matrix | {s['discrepancies']} |",
+        f"| Unverified (skip/error) | {s['unverified']} |",
+        "",
+        "`Failed` is a result, not a defect: it records that the engine does not "
+        "support the feature through Flink SQL. A discrepancy means the observed "
+        "behaviour disagrees with `flink.json`.",
+        "",
+        "## Test Results",
+        "",
+        "| Feature | Version | Result | Matrix | Match | Details |",
+        "|---------|---------|--------|--------|-------|---------|",
+    ]
 
-    lines.append("## Test Results")
-    lines.append("")
-    lines.append("| Feature | Version | Result | JSON Level | Match | Details |")
-    lines.append("|---------|---------|--------|------------|-------|---------|")
-
-    status_emoji = {"pass": "✅", "fail": "❌", "skip": "⏭️", "error": "⚠️"}
-
+    emoji = {"pass": "PASS", "fail": "FAIL", "skip": "SKIP", "error": "ERR"}
     for t in report["tests"]:
-        emoji = status_emoji.get(t["result"], "❓")
-        match_str = "✅" if t["match"] else "❌ DISCREPANCY"
-        details = t["details"][:80].replace("\n", " ").replace("\r", "").replace("|", "\\|") if t["details"] else ""
-        feature_name = t["feature_name"].replace("|", "\\|")
-        json_level = t["json_level"].replace("|", "\\|") if t["json_level"] else ""
+        details = (t["details"] or "")[:150].replace("\n", " ").replace("|", "\\|")
         lines.append(
-            f"| {feature_name} | {t['version']} | {emoji} {t['result']} "
-            f"| {json_level} | {match_str} | {details} |"
+            f"| {t['feature_name'].replace('|', '')} | {t['version']} "
+            f"| {emoji.get(t['result'], '?')} | {t['json_level']} "
+            f"| {'ok' if t['match'] else 'DISCREPANCY'} | {details} |"
         )
-
-    lines.append("")
 
     discs = [t for t in report["tests"] if not t["match"]]
     if discs:
-        lines.append("## ⚠️ Discrepancies")
-        lines.append("")
+        lines += ["", "## Discrepancies", ""]
         for t in discs:
-            detail_clean = t["details"][:120].replace("\n", " ").replace("\r", "") if t["details"] else ""
-            lines.append(f"- **{t['feature_name']}** ({t['version']}): "
-                         f"test={t['result']}, json={t['json_level']} — {detail_clean}")
-        lines.append("")
+            lines.append(
+                f"- **{t['feature_name']}** ({t['version']}): observed `{t['result']}`, "
+                f"matrix says `{t['json_level']}` — {(t['details'] or '')[:300]}"
+            )
 
-    return "\n".join(lines)
+    unver = [t for t in report["tests"] if not t["verified"]]
+    if unver:
+        lines += ["", "## Unverified", "",
+                  "These could not be exercised here, so they neither confirm nor "
+                  "contradict the matrix:", ""]
+        for t in unver:
+            lines.append(
+                f"- **{t['feature_name']}** ({t['version']}): matrix `{t['json_level']}` "
+                f"— {(t['details'] or '')[:200]}"
+            )
+
+    return "\n".join(lines) + "\n"
 
 
 # ---------------------------------------------------------------------------
@@ -785,89 +1412,74 @@ def main():
     print("=" * 70)
     print("  Flink Iceberg Feature Test Suite")
     print("=" * 70)
-    print(f"Flink version: {FLINK_VERSION}")
-    print(f"Flink Iceberg version: {FLINK_ICEBERG_VERSION}")
-    print(f"FLINK_HOME: {FLINK_HOME}")
-    print(f"Warehouse: {WAREHOUSE_DIR}")
-    print(f"Repo root: {REPO_ROOT}")
+    print(f"Mode:            {MODE}")
+    print(f"Flink version:   {FLINK_VERSION}")
+    print(f"Iceberg version: {FLINK_ICEBERG_VERSION}")
+    print(f"REST catalog:    {REST_URI} (warehouse {REST_WAREHOUSE})")
+    print(f"S3 endpoint:     {S3_ENDPOINT}")
+    print(f"JDBC catalog:    {JDBC_URI}")
     print()
 
-    if not FLINK_HOME:
-        print("[FATAL] FLINK_HOME not set. Cannot run Flink SQL client.")
+    if MODE == "local" and not FLINK_HOME:
+        print("[FATAL] No Docker Flink cluster found and FLINK_HOME is not set.")
+        print("        Start one with tests/docker/start-flink.sh")
         sys.exit(1)
 
-    if not os.path.isfile(SQL_CLIENT):
-        print(f"[FATAL] Flink SQL client not found at {SQL_CLIENT}")
-        sys.exit(1)
+    only = os.environ.get("FLINK_ONLY", "").strip()
+    tests = ALL_TESTS
+    if only:
+        wanted = {t.strip() for t in only.split(",") if t.strip()}
+        tests = [t for t in ALL_TESTS if t.__name__.replace("test_", "") in wanted]
+        print(f"[INFO] FLINK_ONLY set; running {len(tests)} test(s): {sorted(wanted)}\n")
 
-    # Clean warehouse
-    if os.path.exists(WAREHOUSE_DIR):
-        shutil.rmtree(WAREHOUSE_DIR, ignore_errors=True)
-    os.makedirs(WAREHOUSE_DIR, exist_ok=True)
     os.makedirs(REPORT_DIR, exist_ok=True)
 
-    # Run all tests
     results = []
-    for test_fn in ALL_TESTS:
-        test_name = test_fn.__name__
-        print(f"\n--- Running {test_name} ---")
-        try:
-            result = test_fn()
+    for version in VERSIONS:
+        print(f"\n{'=' * 70}\n  Format version {version.upper()}\n{'=' * 70}")
+        for test_fn in tests:
+            name = test_fn.__name__
+            print(f"\n--- {name} [{version}] ---")
+            try:
+                result = test_fn(version)
+            except Exception as e:  # noqa: BLE001
+                result = TestResult(
+                    name.replace("test_", "").replace("_", "-"), name, version
+                )
+                result.result = "error"
+                result.details = f"Unhandled exception: {e}"
             results.append(result)
-            icon = {"pass": "✅", "fail": "❌", "skip": "⏭️", "error": "⚠️"}.get(result.result, "?")
-            print(f"  {icon} {result.result}: {result.details[:120]}")
-        except Exception as e:
-            r = TestResult(test_name.replace("test_", "").replace("_", "-"), test_name)
-            r.result = "error"
-            r.details = f"Unhandled exception: {e}"
-            results.append(r)
-            print(f"  ⚠️ error: {e}")
-
-    # Generate report
-    print("\n" + "=" * 70)
-    print("  Generating Report")
-    print("=" * 70)
+            print(f"  {result.result}: {result.details[:160]}")
 
     report = generate_report(results)
 
-    # Write JSON report
     json_path = os.path.join(REPORT_DIR, "flink-iceberg-test-report.json")
     with open(json_path, "w") as f:
         json.dump(report, f, indent=2)
-    print(f"JSON report: {json_path}")
 
-    # Write Markdown report
     md_content = generate_markdown(report)
     md_path = os.path.join(REPORT_DIR, "flink-iceberg-test-report.md")
     with open(md_path, "w") as f:
         f.write(md_content)
-    print(f"Markdown report: {md_path}")
 
-    # Print summary
     s = report["summary"]
     print(f"\n{'=' * 70}")
-    print(f"  RESULTS: {s['passed']} passed, {s['failed']} failed, "
-          f"{s['skipped']} skipped, {s['errors']} errors, "
-          f"{s['discrepancies']} discrepancies")
+    print(f"  {s['passed']} passed, {s['failed']} failed, {s['skipped']} skipped, "
+          f"{s['errors']} errors, {s['discrepancies']} discrepancies, "
+          f"{s['unverified']} unverified")
+    print(f"  Reports: {json_path}")
+    print(f"           {md_path}")
     print(f"{'=' * 70}")
-
-    # Print markdown to stdout
     print("\n" + md_content)
 
-    # GitHub Actions step summary
     summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_file:
         with open(summary_file, "a") as f:
             f.write(md_content)
 
-    # Clean up
-    if os.path.exists(WAREHOUSE_DIR):
-        shutil.rmtree(WAREHOUSE_DIR, ignore_errors=True)
-
-    # Exit code: fail if there are discrepancies or test errors
-    if s["discrepancies"] > 0 or s["errors"] > 0:
-        sys.exit(1)
-    sys.exit(0)
+    # Errors mean the harness itself could not run something; discrepancies mean
+    # the matrix and reality disagree. Both warrant a human look.
+    sys.exit(1 if (s["discrepancies"] > 0 or s["errors"] > 0) else 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Rebuilds the Flink feature suite around a Dockerized Flink 2.3.0 cluster carrying `iceberg-flink-runtime-2.1:1.11.0` (the latest published runtime — Iceberg has no 2.2/2.3 runtime yet), and corrects the Flink matrix data wherever observed behaviour disagreed with what was recorded.

The previous suite reported 15 passed / 18 skipped with zero discrepancies, but 17 tests were hardcoded skips, one returned pass without running SQL, and every skip counted as agreeing with the matrix — so the six `unknown` V3 cells could never be resolved. The suite now reports **42 passed, 4 failed (documented non-support), 24 skipped, 0 errors, 0 discrepancies**, with skips additionally tracked as `unverified` so they can't rubber-stamp the data.

## Infrastructure

- Flink runs as a two-container Docker Compose cluster (`tests/docker/docker-compose.flink.yml` + image build) so the cluster, jars and classpath are identical locally and in CI.
- Lakekeeper now advertises `BASE_URI` on the host IP: Iceberg's REST client applies the server-returned `overrides.uri`, so a `localhost` base URI broke any containerized engine.
- Hadoop 3.4.1 client jars replace `flink-shaded-hadoop-2-uber:2.8.3`: Iceberg 1.11 calls `FileSystem.openFile()` (Hadoop 3.3+), without which every Hadoop/JDBC catalog read fails with `NoSuchMethodError`.
- Postgres is published for the JDBC catalog and the jdbc maintenance lock.
- `table.dml-sync` is set for bounded work (the client otherwise submits INSERT detached and SELECTs race the write) and disabled for unbounded streaming submits, which are polled and always cancelled.

## Streaming coverage

Streaming is what Flink is for, so the suite exercises it directly: unbounded INSERTs must commit multiple append snapshots on checkpoints with rows readable mid-flight; continuous reads (`streaming=true` + `monitor-interval`) must deliver rows committed after the job started; all upsert evidence is produced under the streaming runtime; and in-job post-commit compaction (`flink-maintenance.*`, SQL-configured) is verified to produce a `replace` snapshot inside a running streaming job — no Spark, no external scheduler.

## Matrix data corrections (evidence in the CI-posted report)

- `schema-evolution` partial → **full**: ADD/RENAME/DROP/MODIFY (incl. AFTER reordering) all work via Flink DDL.
- `deletion-vectors` v3 stays **full**, now with proof: same-batch upserts write puffin DVs (`content=1`); cross-commit upserts write equality deletes by design.
- `position-deletes` → **full** with the same mechanism.
- `merge-on-read` → **full**, and upsert is proven MoR-*only* (copy-on-write write modes are silently ignored).
- `copy-on-write` full → **partial**: only whole-table/partition INSERT OVERWRITE is reachable; no row-level UPDATE/DELETE exists to trigger CoW.
- `lineage` v3 full → **partial**: lineage is maintained on write (`next-row-id`, `first-row-id`) but unreadable from Flink SQL.
- `column-default-values` / `geometry-type` v3 unknown → **none** (parser rejects DEFAULT; Calcite gates GEOMETRY with no Flink switch).
- Catalog corrections: `catalog-type` accepts only hive/hadoop/rest — Glue/Nessie/JDBC go through `catalog-impl`; JDBC and Hadoop catalogs are now genuinely round-trip tested.
- `hidden-partitioning` / `partition-evolution`: verified Flink honours transform specs and evolved specs created through the catalog (writes land in correct partitions / new spec, reads span specs); the gap is DDL-only.
- Notes rewritten as durable capability statements matching the other engines' style; Flink-only machinery (Dynamic Sink, in-job maintenance, distribution modes) is surfaced in hover notes rather than as new feature rows.

## Testing

- `npm run build`, `npm test`, `npm run lint` all green.
- Full suite run against the Docker stack: 42/4/24 with 0 errors and 0 discrepancies; no leaked Flink jobs.
- The flink-tests workflow on this PR runs the same suite and posts the full report as a comment.
